### PR TITLE
feat(Cert Key Parser): fingerprint in hex format

### DIFF
--- a/src/tools/certificate-key-parser/certificate-key-parser.infos.ts
+++ b/src/tools/certificate-key-parser/certificate-key-parser.infos.ts
@@ -170,16 +170,21 @@ export function getCertificateLabelValues(cert: Certificate) {
       })), null, 2),
       multiline: true,
     },
-    {
-      label: 'Fingerprint (sha256):',
-      value: onErrorReturnErrorMessage(() => cert.fingerprint('sha256')),
-      multiline: true,
-    },
-    {
-      label: 'Fingerprint (sha512):',
-      value: onErrorReturnErrorMessage(() => cert.fingerprint('sha512')),
-      multiline: true,
-    },
+    ...['sha1', 'sha256', 'sha512'].flatMap(algorithm =>
+      [
+
+        {
+          label: `Fingerprint (${algorithm}):`,
+          value: onErrorReturnErrorMessage(() => cert.fingerprint(algorithm)),
+          multiline: true,
+        },
+        {
+          label: `Fingerprint HEX (${algorithm}):`,
+          value: onErrorReturnErrorMessage(() => cert.fingerprint(algorithm).toString('hex')),
+          multiline: true,
+        },
+      ],
+    ),
     {
       label: 'Certificate (pem):',
       value: onErrorReturnErrorMessage(() => cert.toString('pem')),

--- a/src/tools/certificate-key-parser/certificate-key-parser.infos.ts
+++ b/src/tools/certificate-key-parser/certificate-key-parser.infos.ts
@@ -1,4 +1,5 @@
 import type {
+  AlgorithmHashType,
   Certificate,
   Fingerprint,
   Key,
@@ -175,12 +176,12 @@ export function getCertificateLabelValues(cert: Certificate) {
 
         {
           label: `Fingerprint (${algorithm}):`,
-          value: onErrorReturnErrorMessage(() => cert.fingerprint(algorithm)),
+          value: onErrorReturnErrorMessage(() => cert.fingerprint(algorithm as AlgorithmHashType)),
           multiline: true,
         },
         {
           label: `Fingerprint HEX (${algorithm}):`,
-          value: onErrorReturnErrorMessage(() => cert.fingerprint(algorithm).toString('hex')),
+          value: onErrorReturnErrorMessage(() => cert.fingerprint(algorithm as AlgorithmHashType).toString('hex')),
           multiline: true,
         },
       ],


### PR DESCRIPTION
### Why

Hi 👋 , big fan of it-tools. A modest contribution to the certificate parser to display additional fields. I often find myself needing to compare between algorithms and formats.

### What

Add hexadecimal certificate fingerprint output and sha1 algorithm.

- Extend the certificate parser to output certificate fingerprints in both base64 and hexadecimal formats
- Include sha1 in the list of supported fingerprint algorithms to accommodate additional use cases.

<img width="647" alt="image" src="https://github.com/user-attachments/assets/ab9ba1bb-7805-49e9-9d8a-bde33300ded5" />
