### PR TITLE
feat(RAID calculator): Added non-standard RAID 7/RAID TP (triple parity)

### DIFF
--- a/src/tools/raid-calculator/raid-calculator.service.ts
+++ b/src/tools/raid-calculator/raid-calculator.service.ts
@@ -146,7 +146,7 @@ const raidCalculations: { [key: string]: RaidType } = {
     },
   },
   raid_60: {
-    about: 'RAID 60 stripes multiple RAID 6 arrays together (RAID 6 + RAID 0). Each RAID 6 set can sustain a two drive failures.',
+    about: 'RAID 60 stripes multiple RAID 6 arrays together (RAID 6 + RAID 0). Each RAID 6 set can sustain two drive failures.',
     requirements: 'RAID 60 requires at least 8 disks with 4 minimum per stripe. Stripes must contain an equal number of disks.',
     validate(num: number, size: number, stripeSize: number) {
       return num >= 8 && stripeSize >= 4 && num % stripeSize === 0;
@@ -168,7 +168,7 @@ const raidCalculations: { [key: string]: RaidType } = {
     },
   },
   raid_70: {
-    about: 'RAID 70 stripes multiple RAID 7 arrays together (RAID 7 + RAID 0). Each RAID 7 set can sustain a three drive failures.',
+    about: 'RAID 70 stripes multiple RAID 7 arrays together (RAID 7 + RAID 0). Each RAID 7 set can sustain three drive failures.',
     requirements: 'RAID 70 requires at least 10 disks with 5 minimum per stripe. Stripes must contain an equal number of disks.',
     validate(num: number, size: number, stripeSize: number) {
       return num >= 10 && stripeSize >= 5 && num % stripeSize === 0;

--- a/src/tools/raid-calculator/raid-calculator.service.ts
+++ b/src/tools/raid-calculator/raid-calculator.service.ts
@@ -85,6 +85,25 @@ const raidCalculations: { [key: string]: RaidType } = {
       return '2 drive failures';
     },
   },
+  raid_7: {
+    about: 'RAID 7/RAID TP (non-standard) is similiar to RAID 5 and RAID 6 but with a third parity block. This allows for a third disk failure at the cost of storage reduction equal to three drives.',
+    requirements: 'RAID 7 requires at least 5 disks',
+    validate(num: number, _size: number, _stripeSize: number) {
+      return num >= 5;
+    },
+    capacity(num: number, size: number, stripeSize: number, unit: number) {
+      // (N-3) * S (3 parity)
+      return ((num - 3) * size) * unit;
+    },
+    efficiency(num: number, _stripeSize: number) {
+      // 1 - (3/N)
+      return (1 - (3 / num)) * 100;
+    },
+    fault(_num: number, _size: number, _unit: number) {
+      // always 3 drive failures
+      return '3 drive failures';
+    },
+  },
   raid_10: {
     about: 'RAID 10 is a stripe of mirrors (RAID 1 + RAID 0). Each set of drives is mirrored and striped together so that each drive in the set is fault tolerant within the group.',
     requirements: 'RAID 10 requires an even number of at least 4 disks',
@@ -146,6 +165,28 @@ const raidCalculations: { [key: string]: RaidType } = {
     fault(_num: number, _size: number, _unit: number) {
       // 2 per set
       return '2 drive failures per RAID 6 set';
+    },
+  },
+  raid_70: {
+    about: 'RAID 70 stripes multiple RAID 7 arrays together (RAID 7 + RAID 0). Each RAID 7 set can sustain a three drive failures.',
+    requirements: 'RAID 70 requires at least 10 disks with 5 minimum per stripe. Stripes must contain an equal number of disks.',
+    validate(num: number, size: number, stripeSize: number) {
+      return num >= 10 && stripeSize >= 5 && num % stripeSize === 0;
+    },
+    capacity(num: number, size: number, stripeSize: number, unit: number) {
+      // RAID 7 per stripe
+      const perStripe = ((stripeSize - 3) * size) * unit;
+
+      // sum each stripe
+      return perStripe * (num / stripeSize);
+    },
+    efficiency(num: number, stripeSize: number) {
+      // 1 - (3 / strips per stripe)
+      return (1 - (3 / stripeSize)) * 100;
+    },
+    fault(_num: number, _size: number, _unit: number) {
+      // 2 per set
+      return '3 drive failures per RAID 7 set';
     },
   },
 };

--- a/src/tools/raid-calculator/raid-calculator.vue
+++ b/src/tools/raid-calculator/raid-calculator.vue
@@ -61,7 +61,7 @@ function validateSetup() {
           />
         </div>
       </n-form-item>
-      <n-form-item v-if="['raid_50', 'raid_60'].includes(raidType)" label="Disks per stripe" label-placement="left" label-width="150" mb-2>
+      <n-form-item v-if="['raid_50', 'raid_60', 'raid_70'].includes(raidType)" label="Disks per stripe" label-placement="left" label-width="150" mb-2>
         <n-input-number v-model:value="diskPerStripe" max="10000" min="2" placeholder="Number of disks per stripe (ex: 3)" w-full />
         <n-input v-model:value="totalStripes" placeholder="" readonly ml-1 w-full />
       </n-form-item>
@@ -74,9 +74,11 @@ function validateSetup() {
             { label: 'RAID 1 (mirror)', value: 'raid_1' },
             { label: 'RAID 5 (parity)', value: 'raid_5' },
             { label: 'RAID 6 (double parity)', value: 'raid_6' },
+            { label: 'RAID 7 (triple parity)', value: 'raid_7' },
             { label: 'RAID 10 (mirror + stripe)', value: 'raid_10' },
             { label: 'RAID 50 (parity + stripe)', value: 'raid_50' },
             { label: 'RAID 60 (double parity + stripe)', value: 'raid_60' },
+            { label: 'RAID 70 (triple parity + stripe)', value: 'raid_70' },
           ]"
         />
       </n-form-item>


### PR DESCRIPTION
First of all, huge fan of this tool and already hosting it myself. 

Background for this addition was that I primarily use ZFS and therefore like to calculate RAID-Z1/Z2/Z3 with RAID-Z3 being the newest addition to as least TrueNAS (unsure since when ZFS supports Z3). As RAID-Z3 being the equivalent to RAID TP, also known unofficially as RAID 7, I've kept the naming in the tool and just added RAID 7/TP.

Hint: Untested, quick idea, implemented in GitHub Web Editor. PR as draft for now until tested
