### PR TITLE
Fix: listen on noth IPv4 and IPv6

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,5 +1,6 @@
 server {
     listen 8080;
+    listen [::]:8080;
     server_name _;
     root /usr/share/nginx/html;
     index index.html;


### PR DESCRIPTION
With docker v28 it is now possible to make IPv6 only networks.

This simple line will enable the container to bind to ipv6 addresses and ports.