### PR TITLE
Fix iso-3166-searcher timezones (#191)

### DIFF
--- a/src/tools/iso-3166-searcher/iso-3166-searcher.vue
+++ b/src/tools/iso-3166-searcher/iso-3166-searcher.vue
@@ -186,7 +186,7 @@ onUnmounted(() => {
                   label-width="150px"
                   :label="t('tools.iso-3166-searcher.texts.label-timezones')"
                   label-position="left"
-                  :value="result.timezones.join('\n')"
+                  :value="result.timezones.join(', ')"
                   :readonly="true"
                   mb-1
                 />


### PR DESCRIPTION
I am not sure if it was intended, but I tracked down the line that caused the issue #191 .
I updated the line to display the array to mirror the handling in neighborCountry and languages.

If the multiline result was intended, I would suggest increasing the textbox and adding a scrollbar in said box.