### PR TITLE
feat(unicode-search): Added ability to search using unicode characters

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -5,7 +5,7 @@
 // Read more: https://github.com/vuejs/core/pull/3399
 import '@vue/runtime-core'
 
-export {}
+export { }
 
 declare module '@vue/runtime-core' {
   export interface GlobalComponents {
@@ -357,6 +357,7 @@ declare module '@vue/runtime-core' {
     MttdlCalculator: typeof import('./src/tools/mttdl-calculator/mttdl-calculator.vue')['default']
     MultiLinkDownloader: typeof import('./src/tools/multi-link-downloader/multi-link-downloader.vue')['default']
     MyIp: typeof import('./src/tools/my-ip/my-ip.vue')['default']
+    NA: typeof import('naive-ui')['NA']
     NanoidGenerator: typeof import('./src/tools/nanoid-generator/nanoid-generator.vue')['default']
     NanoMemo: typeof import('./src/tools/nano-memo/nano-memo.vue')['default']
     'NanoMemo.content': typeof import('./src/tools/nano-memo/nano-memo.content.md')['default']

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -3228,7 +3228,7 @@ tools:
       tag-category: Category
       tag-html: Html
       tag-name: Name
-      tag-gt-more-info: '&gt; More info'
+      tag-gt-more-info: 'More info about this character'
   url-cleaner:
     title: Url Cleaner
     description: >-

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -3075,7 +3075,7 @@ tools:
       tag-category: 类别
       tag-html: HTML
       tag-name: 名称
-      tag-gt-more-info: "&gt; 更多信息"
+      tag-gt-more-info: '关于这个角色的更多信息'
   url-cleaner:
     title: URL清理器
     description: |


### PR DESCRIPTION
- Added the ability so search using unicode characters
- Changed English and Chinese translations of `tag-gt-more-info` translation key to remove an unparsed html `&gt;` tag
- Changed indexed `characterName` by removing the unnecessary addition of `"U+${hex})"`. To still show the Unicode hex part, it is now added to the 'name' column

Old:

https://github.com/user-attachments/assets/447f21cd-4aba-4fcb-b62d-f6114163de71

New:

https://github.com/user-attachments/assets/6a2b06f4-8279-4a6a-b225-c350d618a76d
