### PR TITLE
chore: add flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1763464769,
+        "narHash": "sha256-AJHrsT7VoeQzErpBRlLJM1SODcaayp0joAoEA35yiwM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6f374686605df381de8541c072038472a5ea2e2d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,40 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = { nixpkgs, ... }:
+    let
+      eachSystem = f:
+        nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      devShells = eachSystem (pkgs:
+        let
+          playwright-browsers = pkgs.playwright-driver.browsers.override {
+            withFirefox = true;
+            withWebkit = true;
+            withFfmpeg = false;
+          };
+        in
+        {
+          default = pkgs.mkShell {
+            packages = [
+              pkgs.nodejs_22
+              pkgs.pnpm
+              pkgs.nodePackages.typescript
+              pkgs.nodePackages.typescript-language-server
+              playwright-browsers
+              pkgs.playwright-test
+            ];
+
+            shellHook = ''
+              export PLAYWRIGHT_NODEJS_PATH="${pkgs.nodejs_22}/bin/node";
+              export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+              export PLAYWRIGHT_BROWSERS_PATH="${playwright-browsers}"
+              export PLAYWRIGHT_HOST_PLATFORM_OVERRIDE="ubuntu-24.04"
+            '';
+          };
+        });
+    };
+}


### PR DESCRIPTION
This PR adds flake.nix, originally added in #242 but was out of scope.  It's useful for development on Nix and Nix-Darwin based systems.  I was able to get all the functions running in Nix this way, even e2e with Puppeteer.  Webkit tests also all work, but the title tests (i.e. expect page title to be) don't for some strange reason.  I think that's likely a bug with Puppeteer not playing well with Linux.  See https://github.com/NixOS/nixpkgs/issues/398324#issuecomment-2811726411 for more details.