### PR TITLE
feat(Privacy): Changed icon for local tools from 'Lock' to 'DeviceDesktop'

### DIFF
--- a/src/layouts/tool.layout.vue
+++ b/src/layouts/tool.layout.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { Lock, World } from '@vicons/tabler';
+import { DeviceDesktop, World } from '@vicons/tabler';
 
 import { useRoute } from 'vue-router';
 import { useHead } from '@vueuse/head';
@@ -76,6 +76,23 @@ const toolFooter = computed<string>(() => {
 const themeVars = useThemeVars();
 
 const linkTheme = useTheme();
+
+const h1Ref = ref<HTMLElement | null>(null);
+const separatorWidth = ref('200px');
+
+onMounted(() => {
+  if (h1Ref.value) {
+    separatorWidth.value = `${h1Ref.value.offsetWidth}px`;
+  }
+});
+
+watch(() => route.path, () => {
+  nextTick(() => {
+    if (h1Ref.value) {
+      separatorWidth.value = `${h1Ref.value.offsetWidth}px`;
+    }
+  });
+});
 </script>
 
 <template>
@@ -83,7 +100,7 @@ const linkTheme = useTheme();
     <div class="tool-layout">
       <div class="tool-header">
         <div flex flex-nowrap items-center justify-between>
-          <n-h1>
+          <n-h1 ref="h1Ref">
             {{ toolTitle }}
             <n-tooltip
               placement="right"
@@ -95,7 +112,7 @@ const linkTheme = useTheme();
                   v-if="route.meta.externAccessDescription"
                   class="tool-privacy-icon"
                 />
-                <Lock
+                <DeviceDesktop
                   v-else
                   class="tool-privacy-icon"
                 />
@@ -186,7 +203,7 @@ const linkTheme = useTheme();
     }
 
     .separator {
-      width: 200px;
+      width: v-bind(separatorWidth);
       height: 2px;
       background: rgb(161, 161, 161);
       opacity: 0.2;

--- a/src/layouts/tool.layout.vue
+++ b/src/layouts/tool.layout.vue
@@ -76,23 +76,6 @@ const toolFooter = computed<string>(() => {
 const themeVars = useThemeVars();
 
 const linkTheme = useTheme();
-
-const h1Ref = ref<HTMLElement | null>(null);
-const separatorWidth = ref('200px');
-
-onMounted(() => {
-  if (h1Ref.value) {
-    separatorWidth.value = `${h1Ref.value.offsetWidth}px`;
-  }
-});
-
-watch(() => route.path, () => {
-  nextTick(() => {
-    if (h1Ref.value) {
-      separatorWidth.value = `${h1Ref.value.offsetWidth}px`;
-    }
-  });
-});
 </script>
 
 <template>
@@ -100,7 +83,7 @@ watch(() => route.path, () => {
     <div class="tool-layout">
       <div class="tool-header">
         <div flex flex-nowrap items-center justify-between>
-          <n-h1 ref="h1Ref">
+          <n-h1>
             {{ toolTitle }}
             <n-tooltip
               placement="right"
@@ -203,7 +186,7 @@ watch(() => route.path, () => {
     }
 
     .separator {
-      width: v-bind(separatorWidth);
+      width:'100%';
       height: 2px;
       background: rgb(161, 161, 161);
       opacity: 0.2;

--- a/src/modules/command-palette/components/command-palette-option.vue
+++ b/src/modules/command-palette/components/command-palette-option.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Lock, World } from '@vicons/tabler';
+import { DeviceDesktop, World } from '@vicons/tabler';
 import type { PaletteOption } from '../command-palette.types';
 
 const props = withDefaults(defineProps<{ option: PaletteOption; selected?: boolean }>(), {
@@ -31,7 +31,7 @@ const { selected } = toRefs(props);
           v-if="option.externAccessDescription"
           class="tool-privacy-icon"
         />
-        <Lock
+        <DeviceDesktop
           v-else
           class="tool-privacy-icon"
         />


### PR DESCRIPTION
- Changed icon for local tools from 'Lock' to 'DeviceDesktop'
- Changed the width of the seperator below the tool title from 200px to 100%

Old:

<img width="1728" height="360" alt="image" src="https://github.com/user-attachments/assets/c288065e-1d4e-4856-987a-848ada8df43d" />

New:

<img width="1691" height="329" alt="image" src="https://github.com/user-attachments/assets/c2c4b5ba-81e2-4de6-a0ec-172ada7a8cfc" />

The feature you added where you can see if it runs locally or uses api calls is really neat! But when I saw the lock icon for the first time, I was wondering why so many tools were locked. Adding a desktop icon seems more logical to me, and will prevent confusion for other people when seeing this icon