### PR TITLE
feat(pdf-unlock): add password input for decryption

### DIFF
--- a/locales/ar.yml
+++ b/locales/ar.yml
@@ -3464,6 +3464,10 @@ tools:
       title-drag-and-drop-a-pdf-file-here-or-click-to-select-a-file: اسحب وأفلِت ملف PDF هنا، أو انقر لتحديد ملف
       title-logs: السجلات
       label-qpdf: كيو بي دي إف
+      label-password: 'كلمة السر:'
+      placeholder-password: كلمة السر
+      tag-decrypt-pdf: فك تشفير PDF
+      tag-output-file: 'ملف الإخراج:'
   pgp-encryption:
     title: تشفير PGP
     description: تشفير وفك تشفير النص العادي باستخدام مفاتيح PGP.

--- a/locales/da.yml
+++ b/locales/da.yml
@@ -3403,6 +3403,10 @@ tools:
       title-drag-and-drop-a-pdf-file-here-or-click-to-select-a-file: Træk og slip en PDF-fil hertil, eller klik for at vælge en fil
       title-logs: Logfiler
       label-qpdf: qpdf
+      label-password: 'Adgangskode:'
+      placeholder-password: Adgangskode
+      tag-decrypt-pdf: Dekrypter PDF
+      tag-output-file: 'Outputfil:'
   pgp-encryption:
     title: PGP-kryptering
     description: Krypter og dekrypter tekst i klar tekst ved hjælp af PGP-nøgler.

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -3725,6 +3725,10 @@ tools:
         auszuwählen
       title-logs: Protokolle
       label-qpdf: qpdf
+      label-password: 'Passwort:'
+      placeholder-password: Passwort
+      tag-decrypt-pdf: PDF entschlüsseln
+      tag-output-file: 'Ausgabedatei:'
   pgp-encryption:
     title: PGP-Verschlüsselung
     description: Verschlüsseln und entschlüsseln Sie Klartext mit PGP-Schlüsseln.

--- a/locales/el.yml
+++ b/locales/el.yml
@@ -3018,6 +3018,10 @@ tools:
         αρχείο
       title-logs: Αρχεία καταγραφής
       label-qpdf: qpdf
+      label-password: 'Κωδικός πρόσβασης:'
+      placeholder-password: Κωδικός πρόσβασης
+      tag-decrypt-pdf: Αποκρυπτογραφία PDF
+      tag-output-file: 'Αρχείο εξόδου:'
   pgp-encryption:
     title: Κρυπτογράφηση PGP
     description: Κρυπτογράφηση και αποκρυπτογράφηση κειμένου με χρήση κλειδιών PGP.

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2948,6 +2948,10 @@ tools:
       title-drag-and-drop-a-pdf-file-here-or-click-to-select-a-file: Drag and drop a PDF file here, or click to select a file
       title-logs: Logs
       label-qpdf: qpdf
+      label-password: 'Password:'
+      placeholder-password: Password
+      tag-decrypt-pdf: Decrypt PDF
+      tag-output-file: 'Output file:'
   pgp-encryption:
     title: PGP encryption
     description: Encrypt and decrypt text clear text using PGP Keys.

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -2969,6 +2969,10 @@ tools:
         archivo
       title-logs: Registros
       label-qpdf: qpdf
+      label-password: 'Contraseña:'
+      placeholder-password: Contraseña
+      tag-decrypt-pdf: Descifrar PDF
+      tag-output-file: 'Archivo de salida:'
   pgp-encryption:
     title: Cifrado PGP
     description: Cifrar y descifrar texto sin cifrar utilizando claves PGP.

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -2076,7 +2076,7 @@ tools:
       label-pass-controls-the-order-for-filesystem-checks-at-boot:
         "Passer (contrôle la commande pour les vérifications du système de
         fichiers au démarrage):"
-      label-password: "Mot de passe :"
+      label-password: "Mot de passe:"
       label-root-filesystem-first: Système de fichiers racine d'abord
       label-username: "Nom d'utilisateur :"
       placeholder-by-default-standard-mount-options-rw-suid-dev-exec-auto-nouser-async:
@@ -5038,6 +5038,10 @@ tools:
         Faites glisser et déposez un fichier PDF ici, ou cliquez pour
         sélectionner un fichier
       title-logs: Bûches
+      label-password: 'Mot de passe :'
+      placeholder-password: Mot de passe
+      tag-decrypt-pdf: Déchiffrer le PDF
+      tag-output-file: 'Fichier de sortie :'
     title: PDF décrypter et déverrouiller
   percentage-calculator:
     description: Calculez facilement les pourcentages d'une valeur à une autre

--- a/locales/ga.yml
+++ b/locales/ga.yml
@@ -3848,6 +3848,10 @@ tools:
       title-drag-and-drop-a-pdf-file-here-or-click-to-select-a-file: Tarraing agus scaoil comhad PDF anseo, nó cliceáil chun comhad a roghnú
       title-logs: Logaí
       label-qpdf: qpdf
+      label-password: 'Pasfhocal:'
+      placeholder-password: Pasfhocal
+      tag-decrypt-pdf: Díchriptiú PDF
+      tag-output-file: 'Comhad aschur:'
   pgp-encryption:
     title: Criptiú PGP
     description: Criptigh agus díchriptigh téacs soiléir ag baint úsáide as Eochracha PGP.

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -3490,6 +3490,10 @@ tools:
         file
       title-logs: Registri
       label-qpdf: qpdf
+      label-password: 'Password:'
+      placeholder-password: Password
+      tag-decrypt-pdf: Decripta PDF
+      tag-output-file: 'File di output:'
   pgp-encryption:
     title: Crittografia PGP
     description: Crittografa e decrittografa il testo in chiaro utilizzando le chiavi PGP.

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -3223,6 +3223,10 @@ tools:
       title-drag-and-drop-a-pdf-file-here-or-click-to-select-a-file: PDF 파일을 여기에 끌어다 놓거나 클릭하여 파일을 선택하세요.
       title-logs: 로그
       label-qpdf: qpdf
+      label-password: '비밀번호:'
+      placeholder-password: 비밀번호
+      tag-decrypt-pdf: PDF 복호화
+      tag-output-file: '출력 파일:'
   pgp-encryption:
     title: PGP 암호화
     description: PGP 키를 사용하여 일반 텍스트를 암호화하고 해독합니다.

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -3443,6 +3443,10 @@ tools:
       title-drag-and-drop-a-pdf-file-here-or-click-to-select-a-file: Sleep een PDF-bestand hierheen of klik om een bestand te selecteren
       title-logs: Logboeken
       label-qpdf: qpdf
+      label-password: 'Wachtwoord:'
+      placeholder-password: Wachtwoord
+      tag-decrypt-pdf: PDF decoderen
+      tag-output-file: 'Uitvoerbestand:'
   pgp-encryption:
     title: PGP-encryptie
     description: Versleutel en ontsleutel tekst met behulp van PGP-sleutels.

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -2953,6 +2953,10 @@ tools:
       title-drag-and-drop-a-pdf-file-here-or-click-to-select-a-file: Przeciągnij i upuść plik PDF tutaj lub kliknij, aby wybrać plik
       title-logs: Dzienniki
       label-qpdf: qpdf
+      label-password: 'Hasło:'
+      placeholder-password: Hasło
+      tag-decrypt-pdf: Odszyfruj PDF
+      tag-output-file: 'Plik wyjściowy:'
   pgp-encryption:
     title: Szyfrowanie PGP
     description: Szyfruj i odszyfrowuj tekst jawny za pomocą kluczy PGP.

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -2938,6 +2938,10 @@ tools:
       title-drag-and-drop-a-pdf-file-here-or-click-to-select-a-file: Arraste e solte um arquivo PDF aqui ou clique para selecionar um arquivo
       title-logs: Registros
       label-qpdf: qpdf
+      label-password: 'Senha:'
+      placeholder-password: Senha
+      tag-decrypt-pdf: Descriptografar PDF
+      tag-output-file: 'Arquivo de saída:'
   pgp-encryption:
     title: Criptografia PGP
     description: Criptografe e descriptografe texto não criptografado usando chaves PGP.

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -3828,6 +3828,10 @@ tools:
       title-drag-and-drop-a-pdf-file-here-or-click-to-select-a-file: Перетащите PDF-файл сюда или щелкните, чтобы выбрать файл.
       title-logs: Журналы
       label-qpdf: qpdf
+      label-password: 'Пароль:'
+      placeholder-password: Пароль
+      tag-decrypt-pdf: Расшифровать PDF
+      tag-output-file: 'Выходной файл:'
   pgp-encryption:
     title: Шифрование PGP
     description: Шифруйте и дешифруйте текст с использованием PGP-ключей

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -3190,6 +3190,10 @@ tools:
         tıklayın
       title-logs: Günlükler
       label-qpdf: qpdf
+      label-password: 'Şifre:'
+      placeholder-password: Şifre
+      tag-decrypt-pdf: PDF'yi Şifrele
+      tag-output-file: 'Çıktı dosyası:'
   pgp-encryption:
     title: PGP şifrelemesi
     description: PGP Anahtarlarını kullanarak metni şifreleyin ve şifresini çözün.

--- a/locales/uk.yml
+++ b/locales/uk.yml
@@ -3812,6 +3812,10 @@ tools:
       title-drag-and-drop-a-pdf-file-here-or-click-to-select-a-file: Перетягніть PDF-файл сюди або клацніть, щоб вибрати файл
       title-logs: Журнали
       label-qpdf: qpdf
+      label-password: 'Пароль:'
+      placeholder-password: Пароль
+      tag-decrypt-pdf: Розшифрувати PDF
+      tag-output-file: 'Вихідний файл:'
   pgp-encryption:
     title: PGP шифрування
     description: Шифруйте та дешифруйте текст за допомогою PGP ключів

--- a/locales/vi.yml
+++ b/locales/vi.yml
@@ -3471,6 +3471,10 @@ tools:
       title-drag-and-drop-a-pdf-file-here-or-click-to-select-a-file: Kéo và thả tệp PDF vào đây hoặc nhấp để chọn tệp
       title-logs: Nhật ký
       label-qpdf: qpdf
+      label-password: 'Mật khẩu:'
+      placeholder-password: Mật khẩu
+      tag-decrypt-pdf: Giải mã PDF
+      tag-output-file: 'Tệp đầu ra:'
   pgp-encryption:
     title: Mã hóa PGP
     description: Mã hóa và giải mã văn bản rõ ràng bằng khóa PGP.

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -2804,6 +2804,10 @@ tools:
       title-drag-and-drop-a-pdf-file-here-or-click-to-select-a-file: 将PDF文件拖放到此处，或点击选择文件
       title-logs: 日志
       label-qpdf: qpdf
+      label-password: '密码:'
+      placeholder-password: 密码
+      tag-decrypt-pdf: 解密PDF
+      tag-output-file: '输出文件:'
   pgp-encryption:
     title: PGP加密
     description: 使用PGP密钥加密和解密明文

--- a/src/tools/pdf-unlock/pdf-unlock.vue
+++ b/src/tools/pdf-unlock/pdf-unlock.vue
@@ -8,6 +8,7 @@ const { t } = useI18n();
 
 const status = ref<'idle' | 'done' | 'error' | 'processing'>('idle');
 const file = ref<File | null>(null);
+const usePassword = ref(false);
 const password = ref('');
 
 const base64OutputPDF = ref('');
@@ -37,12 +38,14 @@ async function onProcessClicked() {
   try {
     const args = [
       '--decrypt',
-      `--password=${password.value}`,
-      '--warning-exit-0',
-      '--verbose',
-      'in.pdf',
-      'out.pdf',
     ];
+    if (usePassword.value) {
+      args.push(`--password=${password.value}`);
+    }
+    args.push('--warning-exit-0');
+    args.push('--verbose');
+    args.push('in.pdf');
+    args.push('out.pdf');
     const outPdfBuffer = await callMainWithInOutPdf(fileBuffer,
       args,
       0);
@@ -87,12 +90,16 @@ async function callMainWithInOutPdf(data: ArrayBuffer, args: string[], expected_
       </div>
     </div>
 
+    <n-checkbox v-if="file" v-model:checked="usePassword" mt-3 mb-2>
+      {{ t('tools.pdf-unlock.texts.label-password') }}
+    </n-checkbox>
+
     <n-form-item
-      v-if="file"
+      v-if="file && usePassword"
       :label="t('tools.pdf-unlock.texts.label-password')"
       label-placement="left"
       mb-1
-      mt-3
+      mt-2
     >
       <n-input
         v-model:value="password"

--- a/src/tools/pdf-unlock/pdf-unlock.vue
+++ b/src/tools/pdf-unlock/pdf-unlock.vue
@@ -8,6 +8,7 @@ const { t } = useI18n();
 
 const status = ref<'idle' | 'done' | 'error' | 'processing'>('idle');
 const file = ref<File | null>(null);
+const password = ref('');
 
 const base64OutputPDF = ref('');
 const fileName = ref('');
@@ -21,21 +22,29 @@ const { download } = useDownloadFileFromBase64(
   });
 const qpdfCommand = ref('');
 
-async function onPDFFileUploaded(uploadedFile: File) {
+function onPDFFileUploaded(uploadedFile: File) {
   file.value = uploadedFile;
-  const fileBuffer = await uploadedFile.arrayBuffer();
-
   fileName.value = `decrypted_${uploadedFile.name}`;
+}
+
+async function onProcessClicked() {
+  if (!file.value) {
+    return;
+  }
+  const fileBuffer = await file.value.arrayBuffer();
+
   status.value = 'processing';
   try {
+    const args = [
+      '--decrypt',
+      `--password=${password.value}`,
+      '--warning-exit-0',
+      '--verbose',
+      'in.pdf',
+      'out.pdf',
+    ];
     const outPdfBuffer = await callMainWithInOutPdf(fileBuffer,
-      [
-        '--decrypt',
-        '--warning-exit-0',
-        '--verbose',
-        'in.pdf',
-        'out.pdf',
-      ],
+      args,
       0);
     base64OutputPDF.value = `data:application/pdf;base64,${Base64.fromUint8Array(outPdfBuffer)}`;
     status.value = 'done';
@@ -72,7 +81,30 @@ async function callMainWithInOutPdf(data: ArrayBuffer, args: string[], expected_
     <div style="flex: 0 0 100%">
       <div mx-auto max-w-600px>
         <c-file-upload :title="t('tools.pdf-unlock.texts.title-drag-and-drop-a-pdf-file-here-or-click-to-select-a-file')" accept=".pdf" @file-upload="onPDFFileUploaded" />
+        <div v-if="file" mt-2 text-center>
+          <strong>{{ t('tools.pdf-unlock.texts.tag-output-file') }}</strong> {{ fileName }}
+        </div>
       </div>
+    </div>
+
+    <n-form-item
+      v-if="file"
+      :label="t('tools.pdf-unlock.texts.label-password')"
+      label-placement="left"
+      mb-1
+      mt-3
+    >
+      <n-input
+        v-model:value="password"
+        type="password"
+        :placeholder="t('tools.pdf-unlock.texts.placeholder-password')"
+      />
+    </n-form-item>
+
+    <div v-if="file" mt-3 flex justify-center>
+      <c-button :disabled="!file" @click="onProcessClicked()">
+        {{ t('tools.pdf-unlock.texts.tag-decrypt-pdf') }}
+      </c-button>
     </div>
 
     <div mt-3 flex justify-center>

--- a/src/tools/pdf-unlock/pdf-unlock.vue
+++ b/src/tools/pdf-unlock/pdf-unlock.vue
@@ -10,6 +10,8 @@ const status = ref<'idle' | 'done' | 'error' | 'processing'>('idle');
 const file = ref<File | null>(null);
 const usePassword = ref(false);
 const password = ref('');
+const fileBuffer = ref<ArrayBuffer | null>(null);
+const isPasswordError = ref(false);
 
 const base64OutputPDF = ref('');
 const fileName = ref('');
@@ -23,24 +25,20 @@ const { download } = useDownloadFileFromBase64(
   });
 const qpdfCommand = ref('');
 
-function onPDFFileUploaded(uploadedFile: File) {
+async function onPDFFileUploaded(uploadedFile: File) {
   file.value = uploadedFile;
   fileName.value = `decrypted_${uploadedFile.name}`;
-  usePassword.value = false;
-  password.value = '';
+  fileBuffer.value = await uploadedFile.arrayBuffer();
+  isPasswordError.value = false;
+  processFile();
 }
 
-async function onProcessClicked() {
-  if (!file.value) {
-    return;
-  }
-  const fileBuffer = await file.value.arrayBuffer();
+async function processFile() {
+  if (!fileBuffer.value) return;
 
   status.value = 'processing';
   try {
-    const args = [
-      '--decrypt',
-    ];
+    const args = ['--decrypt'];
     if (usePassword.value) {
       args.push(`--password=${password.value}`);
     }
@@ -48,18 +46,22 @@ async function onProcessClicked() {
     args.push('--verbose');
     args.push('in.pdf');
     args.push('out.pdf');
-    const outPdfBuffer = await callMainWithInOutPdf(fileBuffer,
-      args,
-      0);
+    const outPdfBuffer = await callMainWithInOutPdf(fileBuffer.value, args, 0);
     base64OutputPDF.value = `data:application/pdf;base64,${Base64.fromUint8Array(outPdfBuffer)}`;
     status.value = 'done';
-
     download();
+    fileBuffer.value = null;
+    usePassword.value = false;
+    password.value = '';
+    isPasswordError.value = false;
   }
   catch (e) {
     status.value = 'error';
+    const errorLog = logs.value.join('\n').toLowerCase();
+    isPasswordError.value = errorLog.includes('password') || errorLog.includes('encrypted');
   }
 }
+
 
 async function callMainWithInOutPdf(data: ArrayBuffer, args: string[], expected_exitcode: number) {
   qpdfCommand.value = args.join(' ');
@@ -86,34 +88,33 @@ async function callMainWithInOutPdf(data: ArrayBuffer, args: string[], expected_
     <div style="flex: 0 0 100%">
       <div mx-auto max-w-600px>
         <c-file-upload :title="t('tools.pdf-unlock.texts.title-drag-and-drop-a-pdf-file-here-or-click-to-select-a-file')" accept=".pdf" @file-upload="onPDFFileUploaded" />
-        <div v-if="file" mt-2 text-center>
-          <strong>{{ t('tools.pdf-unlock.texts.tag-output-file') }}</strong> {{ fileName }}
-        </div>
       </div>
     </div>
 
-    <n-checkbox v-if="file" v-model:checked="usePassword" mt-3 mb-2>
-      {{ t('tools.pdf-unlock.texts.label-password') }}
-    </n-checkbox>
+    <div v-if="isPasswordError">
+      <n-checkbox v-model:checked="usePassword" mt-3 mb-2>
+        {{ t('tools.pdf-unlock.texts.label-password') }}
+      </n-checkbox>
 
-    <n-form-item
-      v-if="file && usePassword"
-      :label="t('tools.pdf-unlock.texts.label-password')"
-      label-placement="left"
-      mb-1
-      mt-2
-    >
-      <n-input
-        v-model:value="password"
-        type="password"
-        :placeholder="t('tools.pdf-unlock.texts.placeholder-password')"
-      />
-    </n-form-item>
+      <n-form-item
+        v-if="usePassword"
+        :label="t('tools.pdf-unlock.texts.label-password')"
+        label-placement="left"
+        mb-1
+        mt-2
+      >
+        <n-input
+          v-model:value="password"
+          type="password"
+          :placeholder="t('tools.pdf-unlock.texts.placeholder-password')"
+        />
+      </n-form-item>
 
-    <div v-if="file" mt-3 flex justify-center>
-      <c-button :disabled="!file" @click="onProcessClicked()">
-        {{ t('tools.pdf-unlock.texts.tag-decrypt-pdf') }}
-      </c-button>
+      <div mt-3 flex justify-center>
+        <c-button @click="processFile()">
+          {{ t('tools.pdf-unlock.texts.tag-decrypt-pdf') }}
+        </c-button>
+      </div>
     </div>
 
     <div mt-3 flex justify-center>

--- a/src/tools/pdf-unlock/pdf-unlock.vue
+++ b/src/tools/pdf-unlock/pdf-unlock.vue
@@ -34,7 +34,9 @@ async function onPDFFileUploaded(uploadedFile: File) {
 }
 
 async function processFile() {
-  if (!fileBuffer.value) return;
+  if (!fileBuffer.value) {
+    return;
+  }
 
   status.value = 'processing';
   try {
@@ -61,7 +63,6 @@ async function processFile() {
     isPasswordError.value = errorLog.includes('password') || errorLog.includes('encrypted');
   }
 }
-
 
 async function callMainWithInOutPdf(data: ArrayBuffer, args: string[], expected_exitcode: number) {
   qpdfCommand.value = args.join(' ');
@@ -92,7 +93,7 @@ async function callMainWithInOutPdf(data: ArrayBuffer, args: string[], expected_
     </div>
 
     <div v-if="isPasswordError">
-      <n-checkbox v-model:checked="usePassword" mt-3 mb-2>
+      <n-checkbox v-model:checked="usePassword" mb-2 mt-3>
         {{ t('tools.pdf-unlock.texts.label-password') }}
       </n-checkbox>
 

--- a/src/tools/pdf-unlock/pdf-unlock.vue
+++ b/src/tools/pdf-unlock/pdf-unlock.vue
@@ -26,6 +26,8 @@ const qpdfCommand = ref('');
 function onPDFFileUploaded(uploadedFile: File) {
   file.value = uploadedFile;
   fileName.value = `decrypted_${uploadedFile.name}`;
+  usePassword.value = false;
+  password.value = '';
 }
 
 async function onProcessClicked() {


### PR DESCRIPTION
The current pdf decrypt doesn't work at all and is using a wrong tool call. To actually decrypt we would need the previous password.

This PR adds a password input field to PDF unlock tool to properly decrypt password-protected PDFs using qpdf's --password parameter.

Changes:
- Added password ref and input field to pdf-unlock.vue
- Split file upload and processing into separate steps
- Updated qpdf command to include --password parameter
- Added translations for all 19 supported languages:
  - label-password
  - placeholder-password
  - tag-decrypt-pdf
  - tag-output-file