### PR TITLE
fix(date-time-converter): correct date format by RFC3339 in timezone 

### DIFF
--- a/src/tools/date-time-converter/date-time-converter.vue
+++ b/src/tools/date-time-converter/date-time-converter.vue
@@ -218,7 +218,7 @@ function formatDateInTimezone(date: Date | undefined, timezone: string): string 
   }
 
   return withDefaultOnError(() => {
-    return formatInTimeZone(date, timezone, 'yyyy-MM-dd HH:mm:ss XXX');
+    return formatInTimeZone(date, timezone, 'yyyy-MM-dd\'T\'HH:mm:ssXXX');
   }, '');
 }
 </script>


### PR DESCRIPTION
### Background
In the Date-time converter component, the output in the “custom timezone” section used yyyy-MM-dd HH:mm:ss XXX, which is not RFC 3339 compliant because it uses a space instead of the T separator.

### Changes
Updated the custom timezone output format from:
yyyy-MM-dd HH:mm:ss XXX
To:
yyyy-MM-dd'T'HH:mm:ssXXX
