### PR TITLE
fix(tool): HDD calc use a table

### DIFF
--- a/locales/ar.yml
+++ b/locales/ar.yml
@@ -2600,12 +2600,6 @@ tools:
       label-gib: جيجا بايت
       label-tib: تي بي
       label-pib: باي بي
-      label-claimed-capacity: "القدرة المطلوبة:"
-      label-unit: "وحدة:"
-      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1 ميجا بايت = 1024
-        كيلوبايت؛ 1 ميجا بايت = 1000 كيلوبايت؛ 1 جيجابايت = 1024 ميجا بايت؛ 1
-        جيجابايت = 1000 ميجا بايت؛
-      tag-see-here-for-details: انظر هنا للمزيد من التفاصيل
   heic-converter:
     title: محول HEIC
     description: محول HEIC إلى JPEG أو PNG

--- a/locales/ar.yml
+++ b/locales/ar.yml
@@ -2600,6 +2600,10 @@ tools:
       label-gib: جيجا بايت
       label-tib: تي بي
       label-pib: باي بي
+      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1 ميجا بايت = 1024
+        كيلوبايت؛ 1 ميجا بايت = 1000 كيلوبايت؛ 1 جيجابايت = 1024 ميجا بايت؛ 1
+        جيجابايت = 1000 ميجا بايت؛
+      tag-see-here-for-details: انظر هنا للمزيد من التفاصيل
   heic-converter:
     title: محول HEIC
     description: محول HEIC إلى JPEG أو PNG

--- a/locales/da.yml
+++ b/locales/da.yml
@@ -2534,6 +2534,8 @@ tools:
       label-gib: GiB
       label-tib: TiB
       label-pib: PiB
+      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1 MiB = 1024 KiB; 1 MB = 1000 kB; 1 GiB = 1024 MiB; 1 GB = 1000 MB;
+      tag-see-here-for-details: se her for detaljer
   heic-converter:
     title: HEIC-konverter
     description: HEIC-konverter til JPEG eller PNG

--- a/locales/da.yml
+++ b/locales/da.yml
@@ -2534,10 +2534,6 @@ tools:
       label-gib: GiB
       label-tib: TiB
       label-pib: PiB
-      label-claimed-capacity: "Påstået kapacitet:"
-      label-unit: "Enhed:"
-      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1 MiB = 1024 KiB; 1 MB = 1000 kB; 1 GiB = 1024 MiB; 1 GB = 1000 MB;
-      tag-see-here-for-details: se her for detaljer
   heic-converter:
     title: HEIC-konverter
     description: HEIC-konverter til JPEG eller PNG

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -2816,6 +2816,8 @@ tools:
       label-gib: GiB
       label-tib: TiB
       label-pib: PiB
+      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1 MiB = 1024 KiB; 1 MB = 1000 kB; 1 GiB = 1024 MiB; 1 GB = 1000 MB;
+      tag-see-here-for-details: Einzelheiten finden Sie hier
   heic-converter:
     title: HEIC-Konverter
     description: HEIC-Konverter zu JPEG oder PNG

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -2816,10 +2816,6 @@ tools:
       label-gib: GiB
       label-tib: TiB
       label-pib: PiB
-      label-claimed-capacity: "Beanspruchte Kapazität:"
-      label-unit: "Einheit:"
-      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1 MiB = 1024 KiB; 1 MB = 1000 kB; 1 GiB = 1024 MiB; 1 GB = 1000 MB;
-      tag-see-here-for-details: Einzelheiten finden Sie hier
   heic-converter:
     title: HEIC-Konverter
     description: HEIC-Konverter zu JPEG oder PNG

--- a/locales/el.yml
+++ b/locales/el.yml
@@ -2109,6 +2109,8 @@ tools:
       label-gib: GiB
       label-tib: TiB
       label-pib: PiB
+      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1MiB = 1024KiB; 1MB = 1000kB; 1GiB = 1024MiB; 1GB = 1000MB;
+      tag-see-here-for-details: δείτε εδώ για λεπτομέρειες
   heic-converter:
     title: Μετατροπέας HEIC
     description: Μετατροπέας HEIC σε JPEG ή PNG

--- a/locales/el.yml
+++ b/locales/el.yml
@@ -2109,10 +2109,6 @@ tools:
       label-gib: GiB
       label-tib: TiB
       label-pib: PiB
-      label-claimed-capacity: "Ισχυριζόμενη χωρητικότητα:"
-      label-unit: "Μονάδα:"
-      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1MiB = 1024KiB; 1MB = 1000kB; 1GiB = 1024MiB; 1GB = 1000MB;
-      tag-see-here-for-details: δείτε εδώ για λεπτομέρειες
   heic-converter:
     title: Μετατροπέας HEIC
     description: Μετατροπέας HEIC σε JPEG ή PNG

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2081,10 +2081,8 @@ tools:
       label-gib: GiB
       label-tib: TiB
       label-pib: PiB
-      label-claimed-capacity: 'Claimed Capacity:'
-      label-unit: 'Unit:'
-      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1MiB = 1024KiB ; 1MB = 1000kB ; 1GiB = 1024MiB ; 1GB = 1000MB ;
-      tag-see-here-for-details: see here for details
+      column-decimal: Decimal
+      column-binary: Binary
   heic-converter:
     title: HEIC Converter
     description: HEIC Converter to JPEG or PNG

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2081,6 +2081,8 @@ tools:
       label-gib: GiB
       label-tib: TiB
       label-pib: PiB
+      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1MiB = 1024KiB ; 1MB = 1000kB ; 1GiB = 1024MiB ; 1GB = 1000MB ;
+      tag-see-here-for-details: see here for details
       column-decimal: Decimal
       column-binary: Binary
   heic-converter:

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -2072,6 +2072,8 @@ tools:
       label-gib: Gibraltar
       label-tib: TiB
       label-pib: PiB
+      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1 MiB = 1024 KiB; 1 MB = 1000 kB; 1 GiB = 1024 MiB; 1 GB = 1000 MB;
+      tag-see-here-for-details: Ver aquí para más detalles
   heic-converter:
     title: Convertidor HEIC
     description: Convertidor HEIC a JPEG o PNG

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -2072,10 +2072,6 @@ tools:
       label-gib: Gibraltar
       label-tib: TiB
       label-pib: PiB
-      label-claimed-capacity: "Capacidad declarada:"
-      label-unit: "Unidad:"
-      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1 MiB = 1024 KiB; 1 MB = 1000 kB; 1 GiB = 1024 MiB; 1 GB = 1000 MB;
-      tag-see-here-for-details: Ver aquí para más detalles
   heic-converter:
     title: Convertidor HEIC
     description: Convertidor HEIC a JPEG o PNG

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -2219,6 +2219,12 @@ tools:
       label-pib: Pibe
       label-tb: tuberculose
       label-tib: Tib
+      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: |-
+        1MIB = 1024KIB; 
+        1 Mo = 1000 Ko; 
+        1gib = 1024mib; 
+        1 Go = 1000 Mo;
+      tag-see-here-for-details: Voir ici pour plus de détails
     title: Calculatrice de disque dur
   heic-converter:
     description: Convertisseur Heic en jpeg ou png

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -2209,7 +2209,6 @@ tools:
 
       Cet outil convertit la capacité décimale en différentes formes binaires.
     texts:
-      label-claimed-capacity: "Capacité revendiquée :"
       label-gb: GB
       label-gib: Givrer
       label-kb: kb
@@ -2219,14 +2218,7 @@ tools:
       label-pb: PB
       label-pib: Pibe
       label-tb: tuberculose
-      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: |-
-        1MIB = 1024KIB; 
-        1 Mo = 1000 Ko; 
-        1gib = 1024mib; 
-        1 Go = 1000 Mo;
-      tag-see-here-for-details: Voir ici pour plus de détails
       label-tib: Tib
-      label-unit: "Unité :"
     title: Calculatrice de disque dur
   heic-converter:
     description: Convertisseur Heic en jpeg ou png

--- a/locales/ga.yml
+++ b/locales/ga.yml
@@ -2728,6 +2728,8 @@ tools:
       label-gib: GiB
       label-tib: TiB
       label-pib: PiB
+      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1MiB = 1024KiB; 1MB = 1000kB; 1GiB = 1024MiB; 1GB = 1000MB;
+      tag-see-here-for-details: féach anseo le haghaidh sonraí
   heic-converter:
     title: Tiontaire HEIC
     description: Tiontaire HEIC go JPEG nó PNG

--- a/locales/ga.yml
+++ b/locales/ga.yml
@@ -2728,10 +2728,6 @@ tools:
       label-gib: GiB
       label-tib: TiB
       label-pib: PiB
-      label-claimed-capacity: "Cumas Éilithe:"
-      label-unit: "Aonad:"
-      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1MiB = 1024KiB; 1MB = 1000kB; 1GiB = 1024MiB; 1GB = 1000MB;
-      tag-see-here-for-details: féach anseo le haghaidh sonraí
   heic-converter:
     title: Tiontaire HEIC
     description: Tiontaire HEIC go JPEG nó PNG

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -2586,6 +2586,8 @@ tools:
       label-gib: GiB
       label-tib: TiB
       label-pib: PiB
+      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1 MiB = 1024 KiB; 1 MB = 1000 kB; 1 GiB = 1024 MiB; 1 GB = 1000 MB;
+      tag-see-here-for-details: vedi qui per i dettagli
   heic-converter:
     title: Convertitore HEIC
     description: Convertitore HEIC in JPEG o PNG

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -2586,10 +2586,6 @@ tools:
       label-gib: GiB
       label-tib: TiB
       label-pib: PiB
-      label-claimed-capacity: "Capacità dichiarata:"
-      label-unit: "Unità:"
-      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1 MiB = 1024 KiB; 1 MB = 1000 kB; 1 GiB = 1024 MiB; 1 GB = 1000 MB;
-      tag-see-here-for-details: vedi qui per i dettagli
   heic-converter:
     title: Convertitore HEIC
     description: Convertitore HEIC in JPEG o PNG

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -2380,6 +2380,8 @@ tools:
       label-gib: 수코양이
       label-tib: 티비
       label-pib: 피비
+      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1MiB = 1024KiB ; 1MB = 1000kB ; 1GiB = 1024MiB ; 1GB = 1000MB ;
+      tag-see-here-for-details: 자세한 내용은 여기를 참조하세요
   heic-converter:
     title: HEIC 변환기
     description: HEIC를 JPEG 또는 PNG로 변환

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -2380,10 +2380,6 @@ tools:
       label-gib: 수코양이
       label-tib: 티비
       label-pib: 피비
-      label-claimed-capacity: "청구된 용량:"
-      label-unit: "단위:"
-      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1MiB = 1024KiB ; 1MB = 1000kB ; 1GiB = 1024MiB ; 1GB = 1000MB ;
-      tag-see-here-for-details: 자세한 내용은 여기를 참조하세요
   heic-converter:
     title: HEIC 변환기
     description: HEIC를 JPEG 또는 PNG로 변환

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -2563,6 +2563,8 @@ tools:
       label-gib: GiB
       label-tib: TiB
       label-pib: PiB
+      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1MiB = 1024KiB; 1MB = 1000kB; 1GiB = 1024MiB; 1GB = 1000MB;
+      tag-see-here-for-details: zie hier voor details
   heic-converter:
     title: HEIC-converter
     description: HEIC Converter naar JPEG of PNG

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -2563,10 +2563,6 @@ tools:
       label-gib: GiB
       label-tib: TiB
       label-pib: PiB
-      label-claimed-capacity: "Geclaimde capaciteit:"
-      label-unit: "Eenheid:"
-      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1MiB = 1024KiB; 1MB = 1000kB; 1GiB = 1024MiB; 1GB = 1000MB;
-      tag-see-here-for-details: zie hier voor details
   heic-converter:
     title: HEIC-converter
     description: HEIC Converter naar JPEG of PNG

--- a/locales/no.yml
+++ b/locales/no.yml
@@ -2611,6 +2611,8 @@ tools:
       label-gib: GiB
       label-tib: TiB
       label-pib: PiB
+      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1 MiB = 1024 KiB; 1 MB = 1000 kB; 1 GiB = 1024 MiB; 1 GB = 1000 MB;
+      tag-see-here-for-details: se her for detaljer
   heic-converter:
     title: HEIC-konverter
     description: HEIC-konverter til JPEG eller PNG

--- a/locales/no.yml
+++ b/locales/no.yml
@@ -2611,10 +2611,6 @@ tools:
       label-gib: GiB
       label-tib: TiB
       label-pib: PiB
-      label-claimed-capacity: "Påstått kapasitet:"
-      label-unit: "Enhet:"
-      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1 MiB = 1024 KiB; 1 MB = 1000 kB; 1 GiB = 1024 MiB; 1 GB = 1000 MB;
-      tag-see-here-for-details: se her for detaljer
   heic-converter:
     title: HEIC-konverter
     description: HEIC-konverter til JPEG eller PNG

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -2079,10 +2079,6 @@ tools:
       label-gib: Klin
       label-tib: TiB
       label-pib: PiB
-      label-claimed-capacity: "Deklarowana pojemność:"
-      label-unit: "Jednostka:"
-      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1 MiB = 1024 KiB; 1 MB = 1000 kB; 1 GiB = 1024 MiB; 1 GB = 1000 MB;
-      tag-see-here-for-details: zobacz tutaj szczegóły
   heic-converter:
     title: Konwerter HEIC
     description: Konwerter HEIC na JPEG lub PNG

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -2079,6 +2079,8 @@ tools:
       label-gib: Klin
       label-tib: TiB
       label-pib: PiB
+      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1 MiB = 1024 KiB; 1 MB = 1000 kB; 1 GiB = 1024 MiB; 1 GB = 1000 MB;
+      tag-see-here-for-details: zobacz tutaj szczegóły
   heic-converter:
     title: Konwerter HEIC
     description: Konwerter HEIC na JPEG lub PNG

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -2061,10 +2061,6 @@ tools:
       label-gib: GiB
       label-tib: TiB
       label-pib: PiB
-      label-claimed-capacity: "Capacidade reivindicada:"
-      label-unit: "Unidade:"
-      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1 MiB = 1024 KiB; 1 MB = 1000 kB; 1 GiB = 1024 MiB; 1 GB = 1000 MB;
-      tag-see-here-for-details: veja aqui para detalhes
   heic-converter:
     title: Conversor HEIC
     description: Conversor HEIC para JPEG ou PNG

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -2061,6 +2061,8 @@ tools:
       label-gib: GiB
       label-tib: TiB
       label-pib: PiB
+      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1 MiB = 1024 KiB; 1 MB = 1000 kB; 1 GiB = 1024 MiB; 1 GB = 1000 MB;
+      tag-see-here-for-details: veja aqui para detalhes
   heic-converter:
     title: Conversor HEIC
     description: Conversor HEIC para JPEG ou PNG

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -2793,6 +2793,8 @@ tools:
       label-gib: ГиБ
       label-tib: ТиБ
       label-pib: ПиБ
+      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1МиБ = 1024КБ; 1МБ = 1000КБ; 1ГиБ = 1024МиБ; 1ГБ = 1000МБ;
+      tag-see-here-for-details: подробности смотрите здесь
   heic-converter:
     title: Конвертер HEIC
     description: Конвертируйте HEIC в JPEG или PNG

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -2793,10 +2793,6 @@ tools:
       label-gib: ГиБ
       label-tib: ТиБ
       label-pib: ПиБ
-      label-claimed-capacity: "Заявленная вместимость:"
-      label-unit: "Единица:"
-      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1МиБ = 1024КБ; 1МБ = 1000КБ; 1ГиБ = 1024МиБ; 1ГБ = 1000МБ;
-      tag-see-here-for-details: подробности смотрите здесь
   heic-converter:
     title: Конвертер HEIC
     description: Конвертируйте HEIC в JPEG или PNG

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -2294,6 +2294,8 @@ tools:
       label-gib: GiB
       label-tib: TiB
       label-pib: PiB
+      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1MiB = 1024KiB; 1MB = 1000kB; 1GiB = 1024MiB; 1GB = 1000MB;
+      tag-see-here-for-details: Ayrıntılar için buraya bakın
   heic-converter:
     title: HEIC Dönüştürücü
     description: HEIC'i JPEG veya PNG'ye Dönüştürücü

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -2294,10 +2294,6 @@ tools:
       label-gib: GiB
       label-tib: TiB
       label-pib: PiB
-      label-claimed-capacity: "İddia Edilen Kapasite:"
-      label-unit: "Birim:"
-      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1MiB = 1024KiB; 1MB = 1000kB; 1GiB = 1024MiB; 1GB = 1000MB;
-      tag-see-here-for-details: Ayrıntılar için buraya bakın
   heic-converter:
     title: HEIC Dönüştürücü
     description: HEIC'i JPEG veya PNG'ye Dönüştürücü

--- a/locales/uk.yml
+++ b/locales/uk.yml
@@ -2778,10 +2778,6 @@ tools:
       label-gib: ГіБ
       label-tib: ТіБ
       label-pib: PiB
-      label-claimed-capacity: "Заявлена місткість:"
-      label-unit: "Одиниця:"
-      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1 МіБ = 1024 КіБ; 1 МБ = 1000 КБ; 1 ГіБ = 1024 МіБ; 1 ГБ = 1000 МБ;
-      tag-see-here-for-details: див. тут для деталей
   heic-converter:
     title: Конвертер HEIC
     description: Конвертуйте HEIC у JPEG або PNG

--- a/locales/uk.yml
+++ b/locales/uk.yml
@@ -2778,6 +2778,8 @@ tools:
       label-gib: ГіБ
       label-tib: ТіБ
       label-pib: PiB
+      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1 МіБ = 1024 КіБ; 1 МБ = 1000 КБ; 1 ГіБ = 1024 МіБ; 1 ГБ = 1000 МБ;
+      tag-see-here-for-details: див. тут для деталей
   heic-converter:
     title: Конвертер HEIC
     description: Конвертуйте HEIC у JPEG або PNG

--- a/locales/vi.yml
+++ b/locales/vi.yml
@@ -2607,6 +2607,8 @@ tools:
       label-gib: GiB
       label-tib: TiB
       label-pib: PiB
+      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1MiB = 1024KiB; 1MB = 1000kB; 1GiB = 1024MiB; 1GB = 1000MB;
+      tag-see-here-for-details: xem chi tiết tại đây
   heic-converter:
     title: Bộ chuyển đổi HEIC
     description: Bộ chuyển đổi HEIC sang JPEG hoặc PNG

--- a/locales/vi.yml
+++ b/locales/vi.yml
@@ -2607,10 +2607,6 @@ tools:
       label-gib: GiB
       label-tib: TiB
       label-pib: PiB
-      label-claimed-capacity: "Sức chứa được yêu cầu:"
-      label-unit: "Đơn vị:"
-      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1MiB = 1024KiB; 1MB = 1000kB; 1GiB = 1024MiB; 1GB = 1000MB;
-      tag-see-here-for-details: xem chi tiết tại đây
   heic-converter:
     title: Bộ chuyển đổi HEIC
     description: Bộ chuyển đổi HEIC sang JPEG hoặc PNG

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -1968,10 +1968,6 @@ tools:
       label-gib: 吉布
       label-tib: 硼化钛
       label-pib: 派布
-      label-claimed-capacity: 标称容量：
-      label-unit: 单位：
-      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1MiB = 1024KiB；1MB = 1000kB；1GiB = 1024MiB；1GB = 1000MB；
-      tag-see-here-for-details: 详情请查看此处
   heic-converter:
     title: HEIC转换器
     description: 将HEIC转换为JPEG或PNG的转换器

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -1968,6 +1968,8 @@ tools:
       label-gib: 吉布
       label-tib: 硼化钛
       label-pib: 派布
+      tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb: 1MiB = 1024KiB；1MB = 1000kB；1GiB = 1024MiB；1GB = 1000MB；
+      tag-see-here-for-details: 详情请查看此处
   heic-converter:
     title: HEIC转换器
     description: 将HEIC转换为JPEG或PNG的转换器

--- a/src/tools/hdd-calculator/hdd-calculator.service.ts
+++ b/src/tools/hdd-calculator/hdd-calculator.service.ts
@@ -7,8 +7,16 @@ const unitsConversion = {
 };
 
 export type Units = 'kb' | 'mb' | 'gb' | 'tb' | 'pb';
+
+export function toBytes(value: number, unit: Units, type: 'dec' | 'bin') {
+  return value * unitsConversion[unit][type];
+}
+
+export function fromBytes(bytes: number, unit: Units, type: 'dec' | 'bin') {
+  return bytes / unitsConversion[unit][type];
+}
+
 export function getRealSize(claimedCapacity: number, claimedUnit: Units, toUnit: Units) {
-  const fromUnit = unitsConversion[claimedUnit];
-  const toUnitBin = unitsConversion[toUnit].bin;
-  return claimedCapacity * fromUnit.dec / toUnitBin;
-};
+  const bytes = toBytes(claimedCapacity, claimedUnit, 'dec');
+  return fromBytes(bytes, toUnit, 'bin');
+}

--- a/src/tools/hdd-calculator/hdd-calculator.vue
+++ b/src/tools/hdd-calculator/hdd-calculator.vue
@@ -1,54 +1,90 @@
 <script setup lang="ts">
+import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import InputCopyable from '../../components/InputCopyable.vue';
-import type { Units } from './hdd-calculator.service';
-import { getRealSize } from './hdd-calculator.service';
 import { useQueryParam } from '@/composable/queryParams';
+import type { Units } from './hdd-calculator.service';
+import { fromBytes, toBytes } from './hdd-calculator.service';
 
 const { t } = useI18n();
 
-const dec_units = [
-  { value: 'kb', label: t('tools.hdd-calculator.texts.label-kb') },
-  { value: 'mb', label: t('tools.hdd-calculator.texts.label-mb') },
-  { value: 'gb', label: t('tools.hdd-calculator.texts.label-gb') },
-  { value: 'tb', label: t('tools.hdd-calculator.texts.label-tb') },
-  { value: 'pb', label: t('tools.hdd-calculator.texts.label-pb') },
-];
-const bin_units = [
-  { value: 'kb', label: t('tools.hdd-calculator.texts.label-kib') },
-  { value: 'mb', label: t('tools.hdd-calculator.texts.label-mib') },
-  { value: 'gb', label: t('tools.hdd-calculator.texts.label-gib') },
-  { value: 'tb', label: t('tools.hdd-calculator.texts.label-tib') },
-  { value: 'pb', label: t('tools.hdd-calculator.texts.label-pib') },
-];
+const units: Units[] = ['kb', 'mb', 'gb', 'tb', 'pb'];
+
+const labelsDec: Record<string, string> = {
+  kb: t('tools.hdd-calculator.texts.label-kb'),
+  mb: t('tools.hdd-calculator.texts.label-mb'),
+  gb: t('tools.hdd-calculator.texts.label-gb'),
+  tb: t('tools.hdd-calculator.texts.label-tb'),
+  pb: t('tools.hdd-calculator.texts.label-pb'),
+};
+
+const labelsBin: Record<string, string> = {
+  kb: t('tools.hdd-calculator.texts.label-kib'),
+  mb: t('tools.hdd-calculator.texts.label-mib'),
+  gb: t('tools.hdd-calculator.texts.label-gib'),
+  tb: t('tools.hdd-calculator.texts.label-tib'),
+  pb: t('tools.hdd-calculator.texts.label-pib'),
+};
 
 const claimedCapacity = useQueryParam({ tool: 'hdd-calc', name: 'capacity', defaultValue: 1 });
 const claimedUnit = useQueryParam({ tool: 'hdd-calc', name: 'unit', defaultValue: 'tb' });
+
+const totalBytes = ref(toBytes(claimedCapacity.value, claimedUnit.value as Units, 'dec'));
+
+function updateBytes(val: string | number | null, unit: Units, type: 'dec' | 'bin') {
+  if (val === null || val === '') {
+    return;
+  }
+  const numericVal = Number(val);
+  if (Number.isNaN(numericVal)) {
+    return;
+  }
+
+  totalBytes.value = toBytes(numericVal, unit, type);
+
+  // Sync with query params for the default unit (e.g. 1 TB decimal)
+  if (type === 'dec' && unit === 'tb') {
+    claimedCapacity.value = numericVal;
+  }
+}
 </script>
 
 <template>
-  <div>
-    <n-form-item :label="t('tools.hdd-calculator.texts.label-claimed-capacity')">
-      <n-input-number-i18n v-model:value="claimedCapacity" :min="1" />
-    </n-form-item>
-    <c-select
-      v-model:value="claimedUnit"
-      :label="t('tools.hdd-calculator.texts.label-unit')"
-      :options="dec_units"
-    />
-    <n-p>
-      {{ t('tools.hdd-calculator.texts.tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb') }}<n-a href="https://en.wikipedia.org/wiki/Byte" target="_blank" rel="noopener">
-        {{ t('tools.hdd-calculator.texts.tag-see-here-for-details') }}
-      </n-a>
-    </n-p>
-
-    <n-divider />
-
-    <InputCopyable
-      v-for="({ value, label }) in bin_units"
-      :key="value"
-      :label="`Capacity in ${label}:`"
-      :value="getRealSize(claimedCapacity, claimedUnit as Units, value as Units).toFixed(5)"
-    />
-  </div>
+  <n-table :single-line="false" class="hdd-calculator">
+    <thead>
+      <tr>
+        <th>{{ t('tools.hdd-calculator.texts.column-decimal') }}</th>
+        <th>{{ t('tools.hdd-calculator.texts.column-binary') }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for="unit in units" :key="unit">
+        <td>
+          <n-form-item :label="labelsDec[unit]" :show-feedback="false">
+            <InputCopyable
+              :value="Number(fromBytes(totalBytes, unit, 'dec').toFixed(5)).toString()"
+              type="number"
+              @update:value="(val) => updateBytes(val, unit, 'dec')"
+            />
+          </n-form-item>
+        </td>
+        <td>
+          <n-form-item :label="labelsBin[unit]" :show-feedback="false">
+            <InputCopyable
+              :value="Number(fromBytes(totalBytes, unit, 'bin').toFixed(5)).toString()"
+              type="number"
+              @update:value="(val) => updateBytes(val, unit, 'bin')"
+            />
+          </n-form-item>
+        </td>
+      </tr>
+    </tbody>
+  </n-table>
 </template>
+
+<style scoped>
+.hdd-calculator {
+  max-width: 380px;
+  margin: 0 auto;
+}
+</style>

--- a/src/tools/hdd-calculator/hdd-calculator.vue
+++ b/src/tools/hdd-calculator/hdd-calculator.vue
@@ -50,36 +50,46 @@ function updateBytes(val: string | number | null, unit: Units, type: 'dec' | 'bi
 </script>
 
 <template>
-  <n-table :single-line="false" class="hdd-calculator">
-    <thead>
-      <tr>
-        <th>{{ t('tools.hdd-calculator.texts.column-decimal') }}</th>
-        <th>{{ t('tools.hdd-calculator.texts.column-binary') }}</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr v-for="unit in units" :key="unit">
-        <td>
-          <n-form-item :label="labelsDec[unit]" :show-feedback="false">
-            <InputCopyable
-              :value="Number(fromBytes(totalBytes, unit, 'dec').toFixed(5)).toString()"
-              type="number"
-              @update:value="(val) => updateBytes(val, unit, 'dec')"
-            />
-          </n-form-item>
-        </td>
-        <td>
-          <n-form-item :label="labelsBin[unit]" :show-feedback="false">
-            <InputCopyable
-              :value="Number(fromBytes(totalBytes, unit, 'bin').toFixed(5)).toString()"
-              type="number"
-              @update:value="(val) => updateBytes(val, unit, 'bin')"
-            />
-          </n-form-item>
-        </td>
-      </tr>
-    </tbody>
-  </n-table>
+  <div>
+    <n-p>
+      {{ t('tools.hdd-calculator.texts.tag-1mib-1024kib-1mb-1000kb-1gib-1024mib-1gb-1000mb') }}<n-a href="https://en.wikipedia.org/wiki/Byte" target="_blank" rel="noopener">
+        {{ t('tools.hdd-calculator.texts.tag-see-here-for-details') }}
+      </n-a>
+    </n-p>
+
+    <n-divider />
+
+    <n-table :single-line="false" class="hdd-calculator">
+      <thead>
+        <tr>
+          <th>{{ t('tools.hdd-calculator.texts.column-decimal') }}</th>
+          <th>{{ t('tools.hdd-calculator.texts.column-binary') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="unit in units" :key="unit">
+          <td>
+            <n-form-item :label="labelsDec[unit]" :show-feedback="false">
+              <InputCopyable
+                :value="Number(fromBytes(totalBytes, unit, 'dec').toFixed(5)).toString()"
+                type="number"
+                @update:value="(val) => updateBytes(val, unit, 'dec')"
+              />
+            </n-form-item>
+          </td>
+          <td>
+            <n-form-item :label="labelsBin[unit]" :show-feedback="false">
+              <InputCopyable
+                :value="Number(fromBytes(totalBytes, unit, 'bin').toFixed(5)).toString()"
+                type="number"
+                @update:value="(val) => updateBytes(val, unit, 'bin')"
+              />
+            </n-form-item>
+          </td>
+        </tr>
+      </tbody>
+    </n-table>
+  </div>
 </template>
 
 <style scoped>


### PR DESCRIPTION
The currently HDD size calculator can be hard to use.

This PR changes the layout into a table, making it faster to change between unit sizes.

**Before:**

https://github.com/user-attachments/assets/85544d65-0426-43fd-8994-d794e63d942f

**After:**

https://github.com/user-attachments/assets/6d458375-cb24-4b7f-98a7-7db5327e2346