### PR TITLE
fix: add JavaScript mjs MIME type

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -13,6 +13,11 @@ server {
     add_header Cross-Origin-Opener-Policy same-origin;
     add_header Cross-Origin-Embedder-Policy require-corp;
     #add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' http: https: blob:; style-src 'self' 'unsafe-inline' https: http:; img-src 'self' data: blob: https: http:; connect-src data: blob: https: http:; font-src 'self' https: http:; object-src 'none'; base-uri 'self'; form-action 'self';";
+
+    types {
+        application/javascript js mjs;
+    }
+
     location / {
         rewrite ^/it-tools/(.*) /$1 break;
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
Add JavaScript MIME types. After this changes, run with it-tools with docker is correctly working with loading .mjs file


<img width="584" height="587" alt="image" src="https://github.com/user-attachments/assets/34fb4998-b35c-4fa0-882c-3aac97a865af" />
<img width="727" height="75" alt="image" src="https://github.com/user-attachments/assets/6a42b03c-d8cb-4660-928b-be5d2f16acae" />
