### PR TITLE
fix(script): Update set_node_mem.sh to work in MacOS

### DIFF
--- a/set_node_mem.sh
+++ b/set_node_mem.sh
@@ -1,5 +1,14 @@
-memory=$(awk '/MemTotal/{print $2}' /proc/meminfo);
-memory=$((memory / 1024));
-node_options="--max-old-space-size=$((memory - 1024))";
-echo "NODE_OPTIONS=$node_options";
-export NODE_OPTIONS="$node_options";
+#!/bin/bash
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    memory=$(sysctl -n hw.memsize)
+    memory=$((memory / 1024 / 1024))
+else
+    memory=$(awk '/MemTotal/{print $2}' /proc/meminfo)
+    memory=$((memory / 1024))
+fi
+
+node_options="--max-old-space-size=$((memory - 1024))"
+
+echo "NODE_OPTIONS=$node_options"
+export NODE_OPTIONS="$node_options"


### PR DESCRIPTION
For MacOS, `/proc/meminfo` is not a directory, so memory becomes, `0 -1024` which is `-1024`

```
❯ echo $OSTYPE
darwin25.0

❯ cat set_node_mem.sh
memory=$(awk '/MemTotal/{print $2}' /proc/meminfo);
memory=$((memory / 1024));
node_options="--max-old-space-size=$((memory - 1024))";
echo "NODE_OPTIONS=$node_options";
export NODE_OPTIONS="$node_options";%                                                                                 

❯ ./set_node_mem.sh
awk: can't open file /proc/meminfo
 source line number 1
NODE_OPTIONS=--max-old-space-size=-1024

❯ git stash pop
## fix/update-set_node_mem.sh-for-mac
 M set_node_mem.sh
Dropped refs/stash@{0} (153c08bc9152c0fc0e43d7fdb77bd35d6033fdb0)

❯ cat set_node_mem.sh
#!/bin/bash

if [[ "$OSTYPE" == "darwin"* ]]; then
    memory=$(sysctl -n hw.memsize)
    memory=$((memory / 1024 / 1024))
else
    memory=$(awk '/MemTotal/{print $2}' /proc/meminfo)
    memory=$((memory / 1024))
fi

node_options="--max-old-space-size=$((memory - 1024))"

echo "NODE_OPTIONS=$node_options"
export NODE_OPTIONS="$node_options"

❯ ./set_node_mem.sh
NODE_OPTIONS=--max-old-space-size=15360
```