### PR TITLE
fix(Fitness Computer): Change arguments order to fix wrong BMI calculation

### DIFF
--- a/src/tools/fitness-computer/fitness-computer.vue
+++ b/src/tools/fitness-computer/fitness-computer.vue
@@ -85,7 +85,7 @@ const tdee = computed(() =>
 );
 
 const bmi = computed(() =>
-  calculateBMI(height.value, weight.value),
+  calculateBMI(weight.value, height.value),
 );
 
 const idealWeight = computed(() => {


### PR DESCRIPTION
The BMI value calculated by Fitness Computer tool is incorrect. This is due to wrong argument order passed to `calculateBMI` (see sources of [`@finegym/fitness-calc`](https://github.com/finegym-io/fitness-calc/blob/55d2590a110406de62a10e2896e49f039324afe8/src/bmi.ts#L14)). Calculation result for the default values before the fix is presented on screenshot (value of 300 is extremely high):

<img width="1228" height="763" alt="image" src="https://github.com/user-attachments/assets/c534e56e-0695-4931-a4c3-e6d8ebf13383" />

