### PR TITLE
jwt-parser -  show full date with timezone for date claims

### DIFF
--- a/src/tools/jwt-parser/jwt-parser.service.ts
+++ b/src/tools/jwt-parser/jwt-parser.service.ts
@@ -52,5 +52,5 @@ function dateFormatter(value: unknown) {
   }
 
   const date = new Date(Number(value) * 1000);
-  return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+  return date.toString();
 }


### PR DESCRIPTION
## Proposed change

Render the date-based JWT claims (`iat`, `exp`, `nbf`) using the full date representation instead of a bare locale date + time.

**Before**

iat (Issued At)    1516239022   (17/01/2018 23:30:22)

**After**

iat (Issued At)    1516239022   (Wed Jan 17 2018 23:30:22 GMT-0200 (Horário de Verão de Brasília))

## Why

When investigating or debugging a JWT, the timestamp is often very important and displaying the full date right away helps a lot. The previous output (`17/01/2018 23:30:22`) hid two things that matter for that analysis:

- **The UTC offset** (`GMT-0200`), so you can immediately see how the token's time relates to UTC without doing the math in your head.
- **The timezone name**, which makes it unambiguous *which* local time you're looking at.

Seeing the complete date picture lets you reason about a token's validity straight away instead of guessing what locale the short date was rendered in.

## How

`dateFormatter` now returns `date.toString()` instead of ``${date.toLocaleDateString()} ${date.toLocaleTimeString()}``.

each user sees the timestamp in their own browser's timezone and language.

## Notes about the change

- Single-line change in `src/tools/jwt-parser/jwt-parser.service.ts`.
- No new dependencies.
- Applies to all three date claims (`iat`, `exp`, `nbf`) since they share the same formatter.