### PR TITLE
Fix unit in placeholder for Run Pace

### DIFF
--- a/src/tools/running-pace-calculator/running-pace-calculator.vue
+++ b/src/tools/running-pace-calculator/running-pace-calculator.vue
@@ -84,7 +84,7 @@ function calculateStuff() {
       </NFormItem>
 
       <NFormItem label="Time:">
-        <NInput v-model:value="time" placeholder="e.g. 45:00 or 45min or 1h30..." clearable />
+        <NInput v-model:value="time" placeholder="e.g. 45:00 or 45min or 1h30m..." clearable />
       </NFormItem>
 
       <NFormItem label="Pace:">


### PR DESCRIPTION
Fixing a typo in the placeholder for Run Pace Calculator tool.
1h30 returns an error. 1h30m works as expected, cf. https://github.com/Daghall/run-pace#calculatetime