### PR TITLE
feat(Integer Base Converter): space separator support

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -5768,6 +5768,13 @@ tools:
       label-base64-64: Base64 (64)
       placeholder-base64-version-will-be-here: Base64 version will be here...
       tag-custom: "Custom:"
+      label-space-separation: Space separation
+      label-binary-size: Binary size
+      label-octal-size: Octal size
+      label-decimal-size: Decimal size
+      label-hexadecimal-size: Hex size
+      label-base64-size: Base64 size
+      label-custom-size: Custom size
     model:
       text:
         invalid-digit-digit-for-base-finalfrombase: Invalid digit "{0}" for base {1}.

--- a/src/tools/integer-base-converter/integer-base-converter.model.test.ts
+++ b/src/tools/integer-base-converter/integer-base-converter.model.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { convertBase } from './integer-base-converter.model';
+import { convertBase, formatWithSpaces } from './integer-base-converter.model';
 
 describe('integer-base-converter', () => {
   describe('convertBase', () => {
@@ -30,6 +30,30 @@ describe('integer-base-converter', () => {
         expect(convertBase({ value: '42540766411283223938465490632011909384', fromBase: 10, toBase: 16 })).toEqual('20010db8000085a300000000ac1f8908');
         expect(convertBase({ value: '20010db8000085a300000000ac1f8908', fromBase: 16, toBase: 10 })).toEqual('42540766411283223938465490632011909384');
       });
+
+      it('should convert integers even when containing spaces', () => {
+        expect(convertBase({ value: '1010 0101', fromBase: 2, toBase: 16 })).toEqual('a5');
+        expect(convertBase({ value: '192 654', fromBase: 10, toBase: 8 })).toEqual('570216');
+      });
+    });
+  });
+
+  describe('formatWithSpaces', () => {
+    it('should format numbers with spaces correctly from right to left', () => {
+      expect(formatWithSpaces('10100000000000001111000000000000', 8)).toEqual('10100000 00000000 11110000 00000000');
+      expect(formatWithSpaces('a000f000', 4)).toEqual('a000 f000');
+      expect(formatWithSpaces('24000170000', 3)).toEqual('24 000 170 000');
+    });
+
+    it('should handle edge cases', () => {
+      expect(formatWithSpaces('', 3)).toEqual('');
+      expect(formatWithSpaces('12', 3)).toEqual('12');
+      expect(formatWithSpaces('123', 3)).toEqual('123');
+      expect(formatWithSpaces('1234', 3)).toEqual('1 234');
+      expect(formatWithSpaces('12345', 3)).toEqual('12 345');
+      expect(formatWithSpaces('123456', 3)).toEqual('123 456');
+      expect(formatWithSpaces('123', 0)).toEqual('123');
+      expect(formatWithSpaces('123', -1)).toEqual('123');
     });
   });
 });

--- a/src/tools/integer-base-converter/integer-base-converter.model.ts
+++ b/src/tools/integer-base-converter/integer-base-converter.model.ts
@@ -61,3 +61,15 @@ export function convertBase(
   }
   return newValue || '0';
 }
+
+export function formatWithSpaces(value: string, groupSize: number): string {
+  if (groupSize <= 0 || !value) {
+    return value;
+  }
+  const chunks: string[] = [];
+  for (let i = value.length; i > 0; i -= groupSize) {
+    const start = Math.max(0, i - groupSize);
+    chunks.unshift(value.slice(start, i));
+  }
+  return chunks.join(' ');
+}

--- a/src/tools/integer-base-converter/integer-base-converter.vue
+++ b/src/tools/integer-base-converter/integer-base-converter.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n';
 import InputCopyable from '../../components/InputCopyable.vue';
-import { convertBase, hasNumberPrefix } from './integer-base-converter.model';
+import { convertBase, hasNumberPrefix, formatWithSpaces } from './integer-base-converter.model';
 import { getErrorMessageIfThrows } from '@/utils/error';
 import { useQueryParam } from '@/composable/queryParams';
 
@@ -21,9 +21,39 @@ const outputBase = useQueryParam({ tool: 'int-base-conv', name: 'outbase', defau
 
 const hasInputNumberPrefix = computed(() => hasNumberPrefix(input.value));
 
-function errorlessConvert(...args: Parameters<typeof convertBase>) {
+const useSpaceSeparation = ref(false);
+const groupSizes = ref({
+  binary: 8,
+  octal: 3,
+  decimal: 3,
+  hex: 4,
+  base64: 4,
+  custom: 4,
+});
+
+function getGroupSizeForBase(base: number): number {
+  if (!useSpaceSeparation.value) {
+    return 0;
+  }
+  switch (base) {
+    case 2: return groupSizes.value.binary;
+    case 8: return groupSizes.value.octal;
+    case 10: return groupSizes.value.decimal;
+    case 16: return groupSizes.value.hex;
+    case 64: return groupSizes.value.base64;
+    default:
+      return base === outputBase.value ? groupSizes.value.custom : 4;
+  }
+}
+
+function formattedConvert(args: Parameters<typeof convertBase>[0]) {
   try {
-    return convertBase(...args);
+    const converted = convertBase(args);
+    const size = getGroupSizeForBase(args.toBase);
+    if (useSpaceSeparation.value && size > 0) {
+      return formatWithSpaces(converted, size);
+    }
+    return converted;
   }
   catch (err) {
     return '';
@@ -46,6 +76,33 @@ const error = computed(() =>
         <n-input-number-i18n v-model:value="inputBase" max="64" min="2" :placeholder="t('tools.integer-base-converter.texts.placeholder-put-your-input-base-here-ex-10')" w-full />
       </n-form-item>
 
+      <n-form-item :label="t('tools.integer-base-converter.texts.label-space-separation')" label-placement="left" label-width="110" :show-feedback="false" style="margin-top: 10px;">
+        <n-switch v-model:value="useSpaceSeparation" />
+      </n-form-item>
+
+      <div v-if="useSpaceSeparation" style="margin-top: 10px; margin-bottom: 20px; padding-left: 20px; border-left: 2px solid var(--n-border-color)">
+        <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); gap: 10px;">
+          <n-form-item :label="t('tools.integer-base-converter.texts.label-binary-size')" label-placement="top" :show-feedback="false">
+            <n-input-number v-model:value="groupSizes.binary" :min="1" :max="64" size="small" />
+          </n-form-item>
+          <n-form-item :label="t('tools.integer-base-converter.texts.label-octal-size')" label-placement="top" :show-feedback="false">
+            <n-input-number v-model:value="groupSizes.octal" :min="1" :max="64" size="small" />
+          </n-form-item>
+          <n-form-item :label="t('tools.integer-base-converter.texts.label-decimal-size')" label-placement="top" :show-feedback="false">
+            <n-input-number v-model:value="groupSizes.decimal" :min="1" :max="64" size="small" />
+          </n-form-item>
+          <n-form-item :label="t('tools.integer-base-converter.texts.label-hexadecimal-size')" label-placement="top" :show-feedback="false">
+            <n-input-number v-model:value="groupSizes.hex" :min="1" :max="64" size="small" />
+          </n-form-item>
+          <n-form-item :label="t('tools.integer-base-converter.texts.label-base64-size')" label-placement="top" :show-feedback="false">
+            <n-input-number v-model:value="groupSizes.base64" :min="1" :max="64" size="small" />
+          </n-form-item>
+          <n-form-item :label="t('tools.integer-base-converter.texts.label-custom-size')" label-placement="top" :show-feedback="false">
+            <n-input-number v-model:value="groupSizes.custom" :min="1" :max="64" size="small" />
+          </n-form-item>
+        </div>
+      </div>
+
       <n-alert v-if="error" style="margin-top: 25px" type="error">
         {{ error }}
       </n-alert>
@@ -54,35 +111,35 @@ const error = computed(() =>
       <InputCopyable
         :label="t('tools.integer-base-converter.texts.label-binary-2')"
         v-bind="inputProps"
-        :value="errorlessConvert({ value: input, fromBase: inputBase, toBase: 2 })"
+        :value="formattedConvert({ value: input, fromBase: inputBase, toBase: 2 })"
         :placeholder="t('tools.integer-base-converter.texts.placeholder-binary-version-will-be-here')"
       />
 
       <InputCopyable
         :label="t('tools.integer-base-converter.texts.label-octal-8')"
         v-bind="inputProps"
-        :value="errorlessConvert({ value: input, fromBase: inputBase, toBase: 8 })"
+        :value="formattedConvert({ value: input, fromBase: inputBase, toBase: 8 })"
         :placeholder="t('tools.integer-base-converter.texts.placeholder-octal-version-will-be-here')"
       />
 
       <InputCopyable
         :label="t('tools.integer-base-converter.texts.label-decimal-10')"
         v-bind="inputProps"
-        :value="errorlessConvert({ value: input, fromBase: inputBase, toBase: 10 })"
+        :value="formattedConvert({ value: input, fromBase: inputBase, toBase: 10 })"
         :placeholder="t('tools.integer-base-converter.texts.placeholder-decimal-version-will-be-here')"
       />
 
       <InputCopyable
         :label="t('tools.integer-base-converter.texts.label-hexadecimal-16')"
         v-bind="inputProps"
-        :value="errorlessConvert({ value: input, fromBase: inputBase, toBase: 16 })"
+        :value="formattedConvert({ value: input, fromBase: inputBase, toBase: 16 })"
         :placeholder="t('tools.integer-base-converter.texts.placeholder-hexadecimal-version-will-be-here')"
       />
 
       <InputCopyable
         :label="t('tools.integer-base-converter.texts.label-base64-64')"
         v-bind="inputProps"
-        :value="errorlessConvert({ value: input, fromBase: inputBase, toBase: 64 })"
+        :value="formattedConvert({ value: input, fromBase: inputBase, toBase: 64 })"
         :placeholder="t('tools.integer-base-converter.texts.placeholder-base64-version-will-be-here')"
       />
 
@@ -95,7 +152,7 @@ const error = computed(() =>
         <InputCopyable
           flex-1
           v-bind="inputProps"
-          :value="errorlessConvert({ value: input, fromBase: inputBase, toBase: outputBase })"
+          :value="formattedConvert({ value: input, fromBase: inputBase, toBase: outputBase })"
           :placeholder="`Base ${outputBase} will be here...`"
         />
       </div>


### PR DESCRIPTION
Implements #480 

* Adds a "Space separation" toggle switch and group size configuration inputs for common bases (Binary, Octal, Decimal, Hexadecimal, Base64, and Custom base).
* Implemented `formatWithSpaces(value: string, groupSize: number)` formatting logic to dynamically group digits from right to left based on the target base's configured group size.
* Parses input values cleanly by ignoring spaces during the base conversion process.
* Added unit test coverage for `formatWithSpaces` formatting, boundary cases, and space-separated input conversions.