### PR TITLE
fix(layout): prevent horizontal page overflow with wide code content

### DIFF
--- a/src/components/MenuLayout.vue
+++ b/src/components/MenuLayout.vue
@@ -93,6 +93,14 @@ const siderContentWidthPx = computed(() => `${siderContentWidth.value}px`);
 
 .content {
   // background-color: #f1f5f9;
+
+  // Flex items default to min-width: auto, so a child wider than the viewport
+  // (e.g. a long, non-wrapping line in a code viewer) stretches this whole
+  // column past the screen instead of letting the child's own scroll container
+  // (n-scrollbar / CodeMirror) scroll horizontally. min-width: 0 lets the
+  // column shrink to the available width so that inner scrolling kicks in.
+  min-width: 0;
+
   ::v-deep(.n-layout-scroll-container) {
     padding: 26px;
 


### PR DESCRIPTION
Large inputs (e.g. a 64KB JSON pasted into the JSON prettify tool) pushed all tool content off-screen. The mobile UX overhaul (#474) switched the app to document-level scrolling (overflow: visible, no nested scroll container), which exposed that the .content flex column has the default min-width: auto and refuses to shrink below its content's min-content width. A long, non-wrapping code line therefore stretched the whole column past the viewport instead of scrolling inside the viewer.

Set min-width: 0 on the .content flex child so the column shrinks to the available width and the inner scrollers (n-scrollbar / CodeMirror) handle horizontal overflow as intended.