### PR TITLE
fix(docker): run on read-only filesystems, IPv6-less hosts and cpu-limited containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,26 @@ ENV BASE_URL=${BASE_URL}
 COPY --from=build-stage /app/dist /usr/share/nginx/html
 
 COPY nginx.conf /etc/nginx/templates/default.conf.template
+COPY docker-entrypoint.d/ /docker-entrypoint.d/
 ENV PORT=8080
+
+# nginx defaults to `worker_processes auto`, which counts the host's cores and
+# ignores the container's cpu limit. On a large host that is hundreds of
+# workers in a small container: `docker run -m 192m` is enough to get the
+# image OOM-killed on startup. Let the entrypoint size the pool from the cgroup
+# cpu quota instead. Uncapped containers still get one worker per core.
+ENV NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE=1
+
+# Render the template once here as well. The entrypoint normally re-renders it
+# at startup, so a custom $PORT keeps working, but it cannot do so on a
+# read-only filesystem (see docker-entrypoint.d/19-skip-envsubst-if-readonly.envsh).
+# Without this the image would fall back to the stock welcome config from the
+# base image: no SPA fallback, so deep links 404 on refresh, and no COOP/COEP,
+# so the WebAssembly-backed tools stop working.
+RUN envsubst '${PORT}' \
+      < /etc/nginx/templates/default.conf.template \
+      > /etc/nginx/conf.d/default.conf
+
 EXPOSE $PORT
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker-entrypoint.d/19-skip-envsubst-if-readonly.envsh
+++ b/docker-entrypoint.d/19-skip-envsubst-if-readonly.envsh
@@ -1,0 +1,29 @@
+# vim:sw=4:ts=4:et
+#
+# 20-envsubst-on-templates.sh guards its output directory with `[ ! -w $dir ]`,
+# which only inspects permission bits. It therefore does not notice a read-only
+# *mount*: with `docker run --read-only` or a Kubernetes readOnlyRootFilesystem,
+# /etc/nginx/conf.d still looks writable, envsubst runs anyway, the redirect
+# fails with EROFS and `set -e` takes the container down. The image
+# crash-loops on every start.
+#
+# Probe the directory with a real write. If it fails, point the template
+# directory at a path that does not exist so 20-envsubst-on-templates.sh
+# returns early, and let nginx use the config rendered into the image at build
+# time instead. Sourced, not executed, so the export reaches later scripts.
+#
+# On a writable filesystem -- every deployment that works today -- the probe
+# succeeds and nothing is changed.
+
+_envsubst_output_dir="${NGINX_ENVSUBST_OUTPUT_DIR:-/etc/nginx/conf.d}"
+_envsubst_probe="$_envsubst_output_dir/.readonly-probe.$$"
+
+if [ -d "${NGINX_ENVSUBST_TEMPLATE_DIR:-/etc/nginx/templates}" ] \
+    && ! (touch "$_envsubst_probe" 2>/dev/null && rm -f "$_envsubst_probe" 2>/dev/null); then
+    if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
+        echo "19-skip-envsubst-if-readonly.envsh: info: $_envsubst_output_dir is not writable, keeping the config baked into the image"
+    fi
+    export NGINX_ENVSUBST_TEMPLATE_DIR=/nonexistent-read-only-filesystem
+fi
+
+unset _envsubst_output_dir _envsubst_probe

--- a/docker-entrypoint.d/25-remove-ipv6-listen-if-unavailable.sh
+++ b/docker-entrypoint.d/25-remove-ipv6-listen-if-unavailable.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# vim:sw=4:ts=4:et
+#
+# nginx.conf listens on both IPv4 and IPv6. On a host or container runtime with
+# IPv6 disabled, nginx refuses to start:
+#
+#   socket() [::]:8080 failed (97: Address family not supported by protocol)
+#
+# Drop the IPv6 listen directives in that case. This runs after
+# 20-envsubst-on-templates.sh so it edits the rendered config, and it is a
+# no-op wherever IPv6 is available, which is the case the image already
+# handles today.
+
+set -e
+
+ME=$(basename "$0")
+
+entrypoint_log() {
+    if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
+        echo "$@"
+    fi
+}
+
+# Same check the stock 10-listen-on-ipv6-by-default.sh uses.
+if [ -f "/proc/net/if_inet6" ]; then
+    exit 0
+fi
+
+output_dir="${NGINX_ENVSUBST_OUTPUT_DIR:-/etc/nginx/conf.d}"
+
+[ -d "$output_dir" ] || exit 0
+
+# `sed -i` rewrites through a temporary file in the directory, so the directory
+# has to be writable, not only the file. Probe it with a real write, the same
+# way 19-skip-envsubst-if-readonly.envsh does.
+probe="$output_dir/.ipv6-probe.$$"
+if ! (touch "$probe" 2>/dev/null && rm -f "$probe" 2>/dev/null); then
+    entrypoint_log "$ME: info: ipv6 not available, but $output_dir is not writable (read-only file system?), leaving the config alone"
+    exit 0
+fi
+
+for conf in "$output_dir"/*.conf; do
+    [ -f "$conf" ] || continue
+    grep -q -E '^[[:space:]]*listen[[:space:]]+\[::\]' "$conf" || continue
+
+    # An individual file can still be mounted read-only inside a writable
+    # directory, so a failed edit must not take the entrypoint down with it.
+    if sed -i -E 's/^([[:space:]]*)(listen[[:space:]]+\[::\].*)$/\1# \2  # disabled by '"$ME"': no IPv6 on this host/' "$conf" 2>/dev/null; then
+        entrypoint_log "$ME: info: ipv6 not available, disabled IPv6 listen in $conf"
+    else
+        entrypoint_log "$ME: info: ipv6 not available, but can not modify $conf, leaving it alone"
+    fi
+done
+
+exit 0

--- a/nginx.conf
+++ b/nginx.conf
@@ -16,7 +16,16 @@ server {
 
     include /etc/nginx/mime.types;
     types {
-        application/javascript js mjs;
+        # mime.types already maps js, remapping it here only emits a
+        # "duplicate extension" warning on every startup.
+        application/javascript mjs;
+    }
+
+    # Hashed build output. Without this, a missing chunk falls through to
+    # index.html below and is served as text/html with a 200, which the browser
+    # rejects with an opaque MIME error instead of a plain 404.
+    location /assets/ {
+        try_files $uri =404;
     }
 
     location / {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Five small fixes to the Docker image. I found them while running it-tools on OpenShift, where containers run as an arbitrary UID. No application code is changed.

The image is already a good base for this. It uses `nginxinc/nginx-unprivileged`, so it runs as uid 101 on port 8080 and keeps its pid and temp files in `/tmp`. These are the remaining rough edges.

**1. Start on a read-only filesystem**

`docker run --read-only` and Kubernetes `readOnlyRootFilesystem: true` crash-loop the container:

```
20-envsubst-on-templates.sh: line 53: can't create /etc/nginx/conf.d/default.conf: Read-only file system
```

That script checks its output directory with `[ ! -w $dir ]`. This only reads permission bits, so it does not detect a read-only *mount*. The check passes, the write fails, and `set -e` stops the entrypoint.

The new `19-skip-envsubst-if-readonly.envsh` tests the directory with a real write. If it fails, it points `NGINX_ENVSUBST_TEMPLATE_DIR` at a missing path so `20-envsubst-on-templates.sh` exits early. The entrypoint sources `.envsh` files, so the export reaches it.

That is only safe if the config in the image is already correct. Today it is not: the image keeps nginx's stock welcome config, which has no SPA fallback and no COOP/COEP. So the Dockerfile now renders the template at build time as well.

Writable setups do not change. The write test passes, nothing is exported, and the config is rendered at startup as before, so a custom `$PORT` still works.

Note: `NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE` also cannot run on a read-only filesystem, because it edits `/etc/nginx/nginx.conf`. Users who need both should set `worker_processes` in their own `nginx.conf`.

**2. Skip IPv6 when the host has none**

`nginx.conf` always listens on IPv6. Where IPv6 is off, nginx will not start:

```
nginx: [emerg] socket() [::]:8080 failed (97: Address family not supported by protocol)
```

The new `25-remove-ipv6-listen-if-unavailable.sh` comments out those lines. It uses the same `/proc/net/if_inet6` check as nginx's own `10-listen-on-ipv6-by-default.sh`, and exits at once when IPv6 works.

Because `sed -i` rewrites through a temporary file, the script probes the *directory* for writability, not the file, and it tolerates a failed edit. So it can never stop the entrypoint.

**3. Match workers to the cpu limit**

`worker_processes auto` counts the host's cores, not the container's cpu limit. On a 256-core host the image starts 256 workers in any container size. `docker run -m 192m` is enough to be OOM-killed at startup. This is how the problem first appeared for me in Kubernetes.

nginx already ships a script for this. It only needs `NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE` to be set. Containers without a cpu limit keep one worker per core.

**4. Return 404 for missing assets**

All paths fall back to `index.html`, so a missing build file returns HTML:

```
/assets/app-abc123.js  ->  HTTP/1.1 200 OK  Content-Type: text/html
```

The browser then shows a confusing MIME error instead of a 404. Now `/assets/` skips the SPA fallback. Sub-folder requests like `/it-tools/assets/...` still match `location /`, so those deployments do not change.

**5. Stop remapping `js`**

`nginx.conf` includes `mime.types`, which already maps `js`, then maps it again. Every startup logs:

```
[warn] duplicate extension "js", content type: "application/javascript" ...
```

`mime.types` has no entry for `mjs`, so `mjs` stays and `js` goes.

### Additional context

**Fix 3 is the only one that changes a working deployment.** Containers with a cpu limit get fewer workers. That is the goal, but I am happy to remove it if you would rather keep the current default.

Fixes 1 and 2 only apply where the container does not start at all today, so they change nothing for current users.

I could not build the image locally, so I tested each change on the published `sharevb/it-tools:2026.7.11` image with the new files added, on a real cluster:

- read-only filesystem: nginx starts instead of crash-looping and serves `/`, deep links and assets correctly, with COOP/COEP present
- writable filesystem: entrypoint output is identical to today, envsubst still runs
- `/assets/missing.js` → 404, `/assets/<real>.js` → 200 `application/javascript`, deep links → 200 `text/html`
- no `duplicate extension` warning
- IPv6 removal, against the image's BusyBox `sed`: edits a rendered config correctly, is safe to run twice, skips cleanly when the directory is not writable, and never aborts a `set -e` shell
- `envsubst` exists in the production stage, and the build-time output file is owned by uid 101

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Submit the PR against the `chore/all-my-stuffs` branch.
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description, in PLAIN ENGLISH ONLY, in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Run `pnpm install --ignore-scripts && pnpm lint:fix && pnpm typecheck` to ensure pnpm lock, oxlint and typecheck are ok — nothing to run, this PR only touches `Dockerfile`, `nginx.conf` and `docker-entrypoint.d/`.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it. — the repo has no test harness for image behaviour, so the manual tests above are listed instead.
