### PR TITLE
fix(deps): move the two remaining deprecated direct dependencies onto supported versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "crc": "^4.3.2",
     "creditcard": "^0.1.3",
     "creditcard-generator": "^0.0.7",
-    "cron-parser": "4.9.0",
+    "cron-parser": "5.10.0",
     "cron-validator": "^1.4.0",
     "cronstrue": "^3.24.0",
     "cross-spawn": "^7.0.6",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "@vueuse/head": "^1.3.1",
     "@vueuse/integrations": "^14.3.0",
     "@vueuse/router": "^10.11.1",
-    "@xmldom/xmldom": "^0.8.13",
+    "@xmldom/xmldom": "^0.8.14",
     "@xterm/xterm": "^5.5.0",
     "@younestouati/playing-cards-standard-deck": "^6.0.1",
     "@zxcvbn-ts/core": "^3.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   isolated-vm: file:./stubs/empty-stub
   onnxruntime-node: file:./stubs/empty-stub
   elliptic: ^6.6.1
+  '@xmldom/xmldom@0.9.10': 0.9.11
   js-sha256: ^0.11.1
   xlsx: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz
 
@@ -232,8 +233,8 @@ importers:
         specifier: ^10.11.1
         version: 10.11.1(vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3)))(rolldown@1.1.4)(rollup@4.62.2)(vite@8.1.3(@types/node@24.13.3)(jiti@2.7.0)(less@4.6.7)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.39(typescript@6.0.3))(webpack@5.108.3(postcss@8.5.16)))(vue@3.5.39(typescript@6.0.3))
       '@xmldom/xmldom':
-        specifier: ^0.8.13
-        version: 0.8.13
+        specifier: ^0.8.14
+        version: 0.8.14
       '@xterm/xterm':
         specifier: ^5.5.0
         version: 5.5.0
@@ -5118,13 +5119,13 @@ packages:
     engines: {node: '>=10.0.0'}
     deprecated: this version has critical issues, please update to the latest version
 
-  '@xmldom/xmldom@0.8.13':
-    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
+  '@xmldom/xmldom@0.8.14':
+    resolution: {integrity: sha512-T4EDRUBVZYRldYApjEJiU0e1stYWaRAX7CuSnKzrpwdZKo53zGV8/pqfzV6FfwNl9YThD2OumQYvqtvjvgG7aQ==}
     engines: {node: '>=10.0.0'}
     deprecated: this version has critical issues, please update to the latest version
 
-  '@xmldom/xmldom@0.9.10':
-    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
+  '@xmldom/xmldom@0.9.11':
+    resolution: {integrity: sha512-tW8bcK3hsG0/uqSnNz6TK4BkcuZSezoU7DlnYssILmZDktPnSHHuDJJFM0AJv+13gz2r0iGdrj6qqKeUnxXEDg==}
     engines: {node: '>=14.6'}
     deprecated: this version has critical issues, please update to the latest version
 
@@ -12365,7 +12366,7 @@ snapshots:
 
   '@boxyhq/saml20@1.16.0':
     dependencies:
-      '@xmldom/xmldom': 0.9.10
+      '@xmldom/xmldom': 0.9.11
       xml-crypto: 6.1.2
       xml-encryption: 4.0.1
       xml2js: 0.6.2
@@ -15693,9 +15694,9 @@ snapshots:
 
   '@xmldom/xmldom@0.7.13': {}
 
-  '@xmldom/xmldom@0.8.13': {}
+  '@xmldom/xmldom@0.8.14': {}
 
-  '@xmldom/xmldom@0.9.10': {}
+  '@xmldom/xmldom@0.9.11': {}
 
   '@xterm/xterm@5.5.0': {}
 
@@ -17665,7 +17666,7 @@ snapshots:
 
   exifreader@4.41.0:
     optionalDependencies:
-      '@xmldom/xmldom': 0.9.10
+      '@xmldom/xmldom': 0.9.11
 
   expand-tilde@2.0.2:
     dependencies:
@@ -22819,12 +22820,12 @@ snapshots:
   xml-crypto@6.1.2:
     dependencies:
       '@xmldom/is-dom-node': 1.0.1
-      '@xmldom/xmldom': 0.8.13
+      '@xmldom/xmldom': 0.8.14
       xpath: 0.0.33
 
   xml-encryption@4.0.1:
     dependencies:
-      '@xmldom/xmldom': 0.8.13
+      '@xmldom/xmldom': 0.8.14
       escape-html: 1.0.3
       xpath: 0.0.32
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -356,8 +356,8 @@ importers:
         specifier: ^0.0.7
         version: 0.0.7
       cron-parser:
-        specifier: 4.9.0
-        version: 4.9.0
+        specifier: 5.10.0
+        version: 5.10.0
       cron-validator:
         specifier: ^1.4.0
         version: 1.4.0
@@ -6028,10 +6028,9 @@ packages:
   croact@1.0.4:
     resolution: {integrity: sha512-9GhvyzTY/IVUrMQ2iz/mzgZ8+NcjczmIo/t4FkC1CU0CEcau6v6VsEih4jkTa4ZmRgYTF0qXEZLObCzdDFplpw==}
 
-  cron-parser@4.9.0:
-    resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
-    engines: {node: '>=12.0.0'}
-    deprecated: v4 is no longer maintained, upgrade to v5
+  cron-parser@5.10.0:
+    resolution: {integrity: sha512-izNAxJyRWUP8ljBoDSub5WyrVOUlT4SLGShswE7eoRBpp6QUsSycYxLBMJlbshgPBMcPT/nrfgjNY2918ayv2A==}
+    engines: {node: '>=18'}
 
   cron-validator@1.4.0:
     resolution: {integrity: sha512-wGcJ9FCy65iaU6egSH8b5dZYJF7GU/3Jh06wzaT9lsa5dbqExjljmu+0cJ8cpKn+vUyZa/EM4WAxeLR6SypJXw==}
@@ -16599,7 +16598,7 @@ snapshots:
       '@daybrush/utils': 1.13.0
       '@egjs/list-differ': 1.0.1
 
-  cron-parser@4.9.0:
+  cron-parser@5.10.0:
     dependencies:
       luxon: 3.7.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,9 @@ overrides:
   isolated-vm: file:./stubs/empty-stub
   onnxruntime-node: file:./stubs/empty-stub
   elliptic: ^6.6.1
+  # @boxyhq/saml20 pins 0.9.10 exactly, which upstream deprecated for "critical
+  # issues"; 0.9.11 is the patched release of that same line.
+  '@xmldom/xmldom@0.9.10': 0.9.11
   # @it-tools/bip39 pins ^0.9.0, whose Node fallback uses eval("require('crypto')")
   # and triggers rolldown EVAL build warnings; 0.11.x dropped the eval.
   js-sha256: ^0.11.1
@@ -48,7 +51,7 @@ minimumReleaseAgeExclude:
   - unhead@2.1.11 || 2.1.13
   - dompurify@3.3.2 || 3.3.4 || 3.4.0 || 3.4.6 || 3.4.7 || 3.4.8 || 3.4.9 || 3.4.11
   - protocol-buffers-schema@3.6.1
-  - '@xmldom/xmldom@0.8.12 || 0.8.13'
+  - '@xmldom/xmldom@0.8.14 || 0.9.11'
   - mathjs@15.2.0
   - protobufjs@7.5.5 || 7.5.6 || 7.5.8 || 7.6.1 || 7.6.3
   - underscore@1.13.8

--- a/src/tools/cron-alarm/cron-alarm.vue
+++ b/src/tools/cron-alarm/cron-alarm.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n';
 import { Countdown } from 'vue3-flip-countdown';
-import { parseExpression } from 'cron-parser';
+import { CronExpressionParser } from 'cron-parser';
 import { format } from 'date-fns';
 import { useQueryParam } from '@/composable/queryParams';
 
@@ -43,7 +43,7 @@ const cronExpression = computed(() => {
   return `${s} ${m} ${h} * * ${alarmDays.value}`;
 });
 const alarmAtDate = computed(() => {
-  const interval = parseExpression(cronExpression.value);
+  const interval = CronExpressionParser.parse(cronExpression.value);
   return interval.next().toDate();
 });
 

--- a/src/tools/crontab-generator/crontab-generator.service.test.ts
+++ b/src/tools/crontab-generator/crontab-generator.service.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getCronType, getLastExecutionTimes, isCronValid } from './crontab-generator.service';
 
 describe('crontab-generator', () => {
@@ -49,6 +49,33 @@ describe('crontab-generator', () => {
       expect(getCronType('aert')).toBe(false);
       expect(getCronType('40 *')).toBe(false);
     });
+
+    // The two dialects overlap: a 6 field expression parses as standard cron with seconds and as an
+    // AWS expression alike. These pin which side each expression is expected to land on.
+    it.each<[string, 'standard' | 'aws' | false]>([
+      ['* * * * *', 'standard'],
+      ['* * * * * *', 'standard'],
+      ['@daily', 'standard'],
+      ['@hourly', 'standard'],
+      ['*/5 * * * *', 'standard'],
+      ['0 0 * * SUN', 'standard'],
+      ['5 4 * * sun', 'standard'],
+      ['0 0 29 2 *', 'standard'],
+      ['0 0,12 1 */2 *', 'standard'],
+      ['0 10 * * ? *', 'aws'],
+      ['15 12 * * ? *', 'aws'],
+      ['0 8 1 * ? *', 'aws'],
+      ['0/5 8-17 ? * MON-FRI *', 'aws'],
+      ['0 9 ? * 2#1 *', 'aws'],
+      ['30 9 L * ? *', 'aws'],
+      ['0 0 1 1 ? 2026', 'aws'],
+      ['', false],
+      ['   ', false],
+      ['60 * * * *', false],
+      ['0 0 32 * *', false],
+    ])('classifies %s as %s', (expression, type) => {
+      expect(getCronType(expression)).toBe(type);
+    });
   });
 
   describe('getLastExecutionTimes', () => {
@@ -59,6 +86,62 @@ describe('crontab-generator', () => {
       // AWS formats
       expect(getLastExecutionTimes('0 11-22 ? * MON-FRI *')).toHaveLength(5);
       expect(getLastExecutionTimes('0 0 ? * 1 *')).toHaveLength(5);
+    });
+
+    describe('with the clock frozen', () => {
+      beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-03-01T00:00:00.000Z'));
+      });
+
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      it('returns the exact next execution times of a standard expression', () => {
+        expect(getLastExecutionTimes('0 0 * * 1-5', undefined, 3)).toEqual([
+          '2026-03-02T00:00:00.000+00:00',
+          '2026-03-03T00:00:00.000+00:00',
+          '2026-03-04T00:00:00.000+00:00',
+        ]);
+        expect(getLastExecutionTimes('23 0-20/2 * * *', undefined, 3)).toEqual([
+          '2026-03-01T00:23:00.000+00:00',
+          '2026-03-01T02:23:00.000+00:00',
+          '2026-03-01T04:23:00.000+00:00',
+        ]);
+        expect(getLastExecutionTimes('*/15 * * * *', undefined, 3)).toEqual([
+          '2026-03-01T00:15:00.000+00:00',
+          '2026-03-01T00:30:00.000+00:00',
+          '2026-03-01T00:45:00.000+00:00',
+        ]);
+      });
+
+      it('applies the requested timezone, offset included', () => {
+        expect(getLastExecutionTimes('0 12 * * *', 'America/New_York', 3)).toEqual([
+          '2026-03-01T12:00:00.000-05:00',
+          '2026-03-02T12:00:00.000-05:00',
+          '2026-03-03T12:00:00.000-05:00',
+        ]);
+        expect(getLastExecutionTimes('0 12 * * *', 'Asia/Tokyo', 2)).toEqual([
+          '2026-03-01T12:00:00.000+09:00',
+          '2026-03-02T12:00:00.000+09:00',
+        ]);
+      });
+
+      // The aws branch goes through event-cron-parser, which does not read the faked clock, so only
+      // the shape is pinned here rather than a frozen instant.
+      it('returns parseable datetimes for an aws expression', () => {
+        const times = getLastExecutionTimes('0 11-22 ? * MON-FRI *', undefined, 2);
+
+        expect(times).toHaveLength(2);
+        for (const time of times) {
+          expect(Number.isNaN(Date.parse(JSON.parse(time)))).toBe(false);
+        }
+      });
+
+      it('returns nothing for an invalid expression', () => {
+        expect(getLastExecutionTimes('aert')).toEqual([]);
+      });
     });
   });
 });

--- a/src/tools/crontab-generator/crontab-generator.service.ts
+++ b/src/tools/crontab-generator/crontab-generator.service.ts
@@ -12,7 +12,9 @@ function looksLikeAwsExpression(cronExpression: string) {
 }
 
 export function getLastExecutionTimes(cronExpression: string, tz: string | undefined = undefined, count: number = 5) {
-  if (getCronType(cronExpression) === 'standard') {
+  const cronType = getCronType(cronExpression);
+
+  if (cronType === 'standard') {
     const interval = CronExpressionParser.parse(cronExpression, { tz });
     const times: string[] = [];
     for (let i = 0; i < count; i++) {
@@ -22,7 +24,7 @@ export function getLastExecutionTimes(cronExpression: string, tz: string | undef
     }
     return times;
   }
-  if (getCronType(cronExpression) === 'aws') {
+  if (cronType === 'aws') {
     const parsed = new EventCronParser(cronExpression);
     const times = [];
     for (let i = 0; i < count; i++) {
@@ -62,13 +64,18 @@ function isAwsExpression(cronExpression: string) {
 }
 
 export function getCronType(cronExpression: string) {
-  if (!looksLikeAwsExpression(cronExpression) && isStandardExpression(cronExpression)) {
+  // Whichever dialect the marker points at gets asked first, and each parser runs at most once.
+  if (looksLikeAwsExpression(cronExpression)) {
+    if (isAwsExpression(cronExpression)) {
+      return 'aws';
+    }
+
+    return isStandardExpression(cronExpression) ? 'standard' : false;
+  }
+
+  if (isStandardExpression(cronExpression)) {
     return 'standard';
   }
 
-  if (isAwsExpression(cronExpression)) {
-    return 'aws';
-  }
-
-  return isStandardExpression(cronExpression) ? 'standard' : false;
+  return isAwsExpression(cronExpression) ? 'aws' : false;
 }

--- a/src/tools/crontab-generator/crontab-generator.service.ts
+++ b/src/tools/crontab-generator/crontab-generator.service.ts
@@ -1,15 +1,24 @@
-import { parseExpression } from 'cron-parser';
+import { CronExpressionParser } from 'cron-parser';
 import cronstrue from 'cronstrue';
 import EventCronParser from 'event-cron-parser';
 
 export type CronType = 'standard' | 'aws';
 
+// AWS EventBridge requires a '?' in exactly one of the two day fields, and standard cron gives it no
+// meaning. cron-parser v4 rejected those expressions outright, which is how they used to be routed
+// to the aws branch; v5 accepts the six field dialect, so the marker has to do the routing instead.
+function looksLikeAwsExpression(cronExpression: string) {
+  return /(?:^|\s)\?(?:\s|$)/.test(cronExpression);
+}
+
 export function getLastExecutionTimes(cronExpression: string, tz: string | undefined = undefined, count: number = 5) {
   if (getCronType(cronExpression) === 'standard') {
-    const interval = parseExpression(cronExpression, { tz });
-    const times = [];
+    const interval = CronExpressionParser.parse(cronExpression, { tz });
+    const times: string[] = [];
     for (let i = 0; i < count; i++) {
-      times.push(interval.next().toJSON());
+      // v5 types toJSON() as nullable, which the caller joins into a single string; keep the list
+      // the requested length rather than letting a hole shorten it
+      times.push(interval.next().toJSON() ?? '');
     }
     return times;
   }
@@ -30,20 +39,36 @@ export function isCronValid(cronExpression: string, cronType: CronType | 'any' =
   return cronType === 'any' ? !!expressionCronType : expressionCronType === cronType;
 }
 
-export function getCronType(cronExpression: string) {
+function isStandardExpression(cronExpression: string) {
   try {
-    parseExpression(cronExpression);
+    CronExpressionParser.parse(cronExpression);
     cronstrue.toString(cronExpression, { throwExceptionOnParseError: true });
-    return 'standard';
+    return true;
   }
   catch (_) {
-    try {
-      const parsed = new EventCronParser(cronExpression);
-      parsed.validate();
-      return 'aws';
-    }
-    catch (_) {
-    }
+    return false;
   }
-  return false;
+}
+
+function isAwsExpression(cronExpression: string) {
+  try {
+    const parsed = new EventCronParser(cronExpression);
+    parsed.validate();
+    return true;
+  }
+  catch (_) {
+    return false;
+  }
+}
+
+export function getCronType(cronExpression: string) {
+  if (!looksLikeAwsExpression(cronExpression) && isStandardExpression(cronExpression)) {
+    return 'standard';
+  }
+
+  if (isAwsExpression(cronExpression)) {
+    return 'aws';
+  }
+
+  return isStandardExpression(cronExpression) ? 'standard' : false;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -175,6 +175,9 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url)),
       'node:fs/promises': fileURLToPath(new URL('./src/_empty.ts', import.meta.url)),
       'node:fs': fileURLToPath(new URL('./src/_empty.ts', import.meta.url)),
+      // Must come before the bare `fs` entry: aliases match by prefix, so `fs` alone would rewrite
+      // `fs/promises` to `_empty.ts/promises`. cron-parser's CronFileParser reaches for it.
+      'fs/promises': fileURLToPath(new URL('./src/_empty.ts', import.meta.url)),
       fs: fileURLToPath(new URL('./src/_empty.ts', import.meta.url)),
       '@babel/core': fileURLToPath(new URL('./src/_empty.ts', import.meta.url)),
       'isolated-vm': fileURLToPath(new URL('./src/_empty.ts', import.meta.url)),


### PR DESCRIPTION
### Description

The description of #557 claimed that after those replacements "no deprecated direct dependencies" were left. **That was wrong**, and this PR fixes what it missed. Apologies for the incorrect claim in that description.

The sweep behind it checked each package's *latest* published version for a deprecation flag rather than the version actually resolved. pnpm does not cover the gap either: its `deprecated subdependencies` warning, by design, only reports **sub**dependencies, so a deprecated *direct* dependency is invisible to both. Re-scanning every entry in `pnpm-lock.yaml` against the registry, at its resolved version, found two:

| Direct dependency | Resolved | Upstream message |
| --- | --- | --- |
| `@xmldom/xmldom` | 0.8.13 | "this version has critical issues, please update to the latest version" |
| `cron-parser` | 4.9.0 (exact pin) | "v4 is no longer maintained, upgrade to v5" |

### `@xmldom/xmldom` → 0.8.14 / 0.9.11

Both 0.8.13 and 0.9.10 are deprecated for **critical issues**; 0.8.14 and 0.9.11 are the patched releases of those same lines. The direct range moves to `^0.8.14`, which also lifts `xml-crypto` and `xml-encryption` since both accept the whole 0.8 line. `@boxyhq/saml20` pins `0.9.10` exactly, so a version-scoped override takes it to 0.9.11.

`epubjs` asks for `^0.7.5` and the 0.7 line has **no** release that is not deprecated, so 0.7.13 stays until epubjs moves. Overriding it across two minors of an XML parser is not something to do blind.

The stale `minimumReleaseAgeExclude` entry, which still named 0.8.12 and 0.8.13, is refreshed. That policy is not currently switched on (`pnpm config get minimumReleaseAge` → undefined), but 0.8.14 is recent and that list is where this repo records such things.

### `cron-parser` v4 → v5, and the trap in it

The rename is mechanical (`parseExpression` → `CronExpressionParser.parse`). The upgrade is not, because **v5 accepts the six-field AWS dialect that v4 rejected**.

`getCronType` depended on that rejection: it tried the standard parser first and treated a throw as the signal to fall through to `event-cron-parser`. Under a naive v5 bump, `0 11-22 ? * MON-FRI *` parses as standard — so AWS expressions would be classified as standard, given the **wrong next execution times**, and reported as invalid whenever the AWS dialect was explicitly requested. Silently, in a tool whose whole job is telling you when your cron fires.

Detection now keys off the `?` marker, which AWS EventBridge *requires* in one of the two day fields and which standard cron gives no meaning to. Checked against v4 over a 32-expression corpus spanning both dialects: **identical classification on all 32**, including `* * * * * *`, which is valid in both and stays `standard` exactly as it did on v4.

`getLastExecutionTimes` keeps returning `string[]`: v5 types `toJSON()` as nullable and the caller `.join()`s the array, so a hole would have rendered as a silent blank line. The output format is unchanged — v5 emits the same non-standard `2026-03-02T00:00:00.000+00:00` form as v4, offsets included, which is what the tool displays.

**Same demonstration as #557.** `f8031db2` adds the tests against v4 (the existing ones only asserted that five items came back, and covered four expressions); `33c10da8` does the upgrade without touching a single assertion:

```
$ git diff --quiet f8031db2 33c10da8 -- src/tools/crontab-generator/crontab-generator.service.test.ts
  (no output — byte identical)
```

### A build break this caught

v5 adds `CronFileParser`, exported from the package entry, which does `require('fs/promises')` to read crontab files. `vite build` failed with `UNLOADABLE_DEPENDENCY: Not a directory` — the alias list stubbed `node:fs/promises` but not the bare specifier, and since Vite matches aliases by prefix, the bare `fs` entry was rewriting `fs/promises` into `_empty.ts/promises`. Fixed by adding a `fs/promises` entry ahead of `fs`. Worth knowing that `pnpm build` is the only check that catches this — tests, lint and typecheck were all green while it was broken.

### What is left, and why

This takes the tree to **17 deprecated packages**, and with my companion `w-websocket-client` PR merged, **16 remain**. **All 16 are transitive and none is reachable from this repo** — each needs its owner to move:

| Deprecated | Comes from |
| --- | --- |
| `@babel/polyfill`, `core-js@2` | `image-compare-viewer`; `core-js@2` also via `composerize` / `composeverter` / `decomposerize` / `podletjs` |
| `@xmldom/xmldom@0.7.13`, `@types/localforage` | `epubjs` |
| `glob@7/8/10/11`, `inflight` | `vue-i18n-extract` (dev), `curlconverter`, `jsonschema-protobuf`; `inflight` disappears with `glob@7/8` |
| `phin@2.9.3`, `phin@3.7.1` | `potrace` → `jimp@0.14` |
| `lodash.get` | `json-analyzer` |
| `node-domexception` | `parse-torrent` → `cross-fetch-ponyfill` → `node-fetch` |
| `string-at` | `json-to-ts` → `es7-shim` |
| `source-map@0.8.0-beta.0` | `@intlify/unplugin-vue-i18n` (dev) and others |
| `uuid@9.0.1` | `fanger` → `ioc-extractor` |

Forcing these with overrides means pushing majors (`core-js` 2→3, `uuid` 9→14) under packages written against the old APIs, which trades a deprecation warning for a real runtime break. Not worth it.

This is independent of my other open follow-up (the `w-websocket-client` one) — the two branches merge cleanly against each other and against `chore/all-my-stuffs`, so they can go in either order.

`pnpm lint`, `pnpm typecheck`, `pnpm test` (128 files / 1059 tests) and `pnpm build` are all green, and `pnpm install --frozen-lockfile` passes.

---

### What is the purpose of this pull request?

- [X] Bug fix — the AWS cron regression this upgrade would otherwise have introduced
- [ ] New Feature
- [ ] Documentation update
- [X] Other — dependency maintenance

### Before submitting the PR, please make sure you do the following

- [X] Submit the PR against the `chore/all-my-stuffs` branch.
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description, in PLAIN ENGLISH ONLY, in this PR that addresses **what** the PR is solving, or reference the issue that it solves.
- [X] Run `pnpm install --ignore-scripts && pnpm lint:fix && pnpm typecheck` to ensure pnpm lock, oxlint and typecheck are ok.
- [X] Ideally, include relevant tests that fail without this PR but pass with it.

---
_Generated by [Claude Code](https://claude.ai/code)_
