### PR TITLE
feat(new tool): Restic Command Generator

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -9969,6 +9969,186 @@ tools:
         get-a-random-tool-from-the-list: Get a random tool from the list.
         random-tool: Random tool
         tools: Tools
+  restic-command-generator:
+    title: Restic Command Generator
+    description: "Generate restic CLI commands to restore a Backrest or plain restic
+      repository: a whole snapshot, only some files, or a browsable mount."
+    texts:
+      intro: "Generator only: nothing runs here and nothing you type leaves your
+        browser. Describe your repository, pick what you need to recover, and copy
+        the shell snippet."
+      title-repository: Repository
+      label-backend: Backend
+      backend-s3: S3 compatible (Backblaze B2, MinIO, Wasabi, AWS…)
+      backend-b2: Backblaze B2 (native)
+      backend-local: Local path or mounted disk
+      backend-sftp: SFTP
+      backend-rest: restic REST server
+      backend-rclone: Rclone
+      backend-azure: Azure Blob Storage
+      backend-gs: Google Cloud Storage
+      backend-raw: Other (raw repository URI)
+      label-local-path: Repository path
+      label-endpoint: Endpoint
+      label-bucket: Bucket
+      label-prefix: Path in the bucket
+      label-region: Region (optional)
+      label-user: User
+      label-host: Host
+      label-port: Port (optional)
+      label-path: Repository path
+      label-url: Server URL
+      label-remote: Rclone remote and path
+      label-container: Container
+      label-raw-repository: Repository URI
+      label-repository-mode: Repository passed as
+      repository-flag: -r flag on every command
+      repository-env: RESTIC_REPOSITORY environment variable
+      label-repository-uri: Repository URI
+      label-password: Repository password
+      password-prompt: Prompt for it in the shell (read -rs, stays out of the history)
+      password-file: --password-file
+      password-command: --password-command
+      password-placeholder: RESTIC_PASSWORD export with a placeholder
+      password-none: Already set in my environment
+      label-password-file: Password file
+      label-password-command: Password command
+      label-credentials: Backend credentials
+      credentials-prompt: Prompt for the secret in the shell
+      credentials-placeholder: Export them with placeholders
+      credentials-none: Already set in my environment
+      label-account-id: Key ID / account name
+      hint-secrets: 'No secret is ever put in the generated command: the prompt
+        options read them into your shell with "read -rs" so they stay out of your
+        history.'
+      title-operation: What do you want to do?
+      operation-restore: restore — write files from a snapshot back to disk
+      operation-dump: dump — stream one file or folder out of a snapshot
+      operation-mount: mount — browse the repository as a filesystem
+      operation-snapshots: snapshots — list the snapshots of the repository
+      operation-ls: ls — list the files inside a snapshot
+      operation-find: find — locate a file across snapshots
+      operation-diff: diff — compare two snapshots
+      operation-check: check — verify the integrity of the repository
+      operation-stats: stats — size of a snapshot or of the repository
+      operation-unlock: unlock — remove stale locks
+      title-snapshot: Snapshot selection
+      label-snapshot-id: Snapshot ID
+      label-subfolder: Only this subfolder of the snapshot
+      label-plan: Backrest plan ID
+      label-instance: Backrest instance ID
+      label-filter-host: Host
+      label-tags: Extra tags
+      placeholder-tag: manual
+      label-filter-paths: Paths
+      placeholder-path: /home/me/documents
+      hint-tags: Backrest tags the snapshots it creates with "plan:" and
+        "created-by:" followed by the plan and the instance IDs. Tags inside a
+        single --tag are ANDed while repeated --tag flags are ORed, so the plan
+        and the instance stay in one flag and each extra tag gets its own.
+      title-restore-options: Restore options
+      label-target: Target directory
+      label-include: Restore only these paths or patterns
+      placeholder-include: /home/me/documents/**/*.pdf
+      label-exclude: Exclude these paths or patterns
+      placeholder-exclude: "**/node_modules"
+      label-overwrite: Overwrite existing files
+      overwrite-default: restic default (always)
+      overwrite-always: always
+      overwrite-if-changed: if-changed
+      overwrite-if-newer: if-newer
+      overwrite-never: never
+      label-case-insensitive: Case insensitive patterns
+      label-dry-run: Dry run
+      label-verify: Verify restored files
+      label-sparse: Write sparse files
+      label-delete: Delete files missing from the snapshot
+      title-dump-options: Dump options
+      label-dump-path: File or folder inside the snapshot
+      label-archive: Archive format
+      archive-none: Raw file
+      archive-tar: tar
+      archive-zip: zip
+      label-output-file: Redirect to a local file (optional)
+      hint-dump: dump streams a single file or folder straight out of the repository,
+        so you do not have to restore a whole snapshot to get one config file
+        back.
+      title-mount-options: Mount options
+      label-mount-point: Mount point
+      label-allow-other: Allow other users to access the mount
+      title-ls-options: List options
+      label-ls-directory: Directory to list (optional)
+      label-long: Long listing
+      label-recursive: Recursive
+      title-find-options: Find options
+      label-find-pattern: Pattern
+      label-restrict-snapshot: Search only the selected snapshot
+      title-diff-options: Diff options
+      label-diff-snapshot: Compare with snapshot
+      label-metadata: Report metadata changes too
+      title-snapshots-options: Snapshots options
+      label-compact: Compact output
+      title-check-options: Check options
+      label-read-data-subset: Read data subset
+      label-read-data: Read and verify every pack file
+      label-check-unused: Report unused blobs
+      label-with-cache: Use the existing cache
+      title-stats-options: Stats options
+      label-stats-mode: Counting mode
+      stats-restore-size: restore-size — size of a restore
+      stats-files-by-contents: files-by-contents — unique files
+      stats-raw-data: raw-data — size before deduplication
+      stats-blobs-per-file: blobs-per-file
+      label-stats-all: All snapshots
+      title-unlock-options: Unlock options
+      label-remove-all: Remove every lock, including the ones in use
+      title-global-options: Global options
+      label-cache-dir: Cache directory
+      label-limit-download: Download limit (KiB/s)
+      label-retry-lock: Retry a locked repository for
+      label-extra-options: Backend options (-o)
+      placeholder-extra-option: s3.connections=4
+      label-extra-arguments: Extra arguments (appended as-is)
+      label-no-lock: --no-lock
+      label-no-cache: --no-cache
+      label-insecure-tls: --insecure-tls
+      label-json: --json
+      label-quiet: --quiet
+      label-verbose: --verbose
+      title-output: Generated command
+      label-include-environment: Include the environment setup
+      label-multiline: One argument per line
+      button-reset: Reset to defaults
+      warning-history: "Placeholder exports stay in your shell history once filled in:
+        prefer the prompt options, or clear the history afterwards."
+      warning-target: restore recreates the full path of every file under the
+        target directory, so /etc/hosts ends up in the etc/hosts subfolder of the
+        target.
+      warning-delete: --delete removes the files of the target directory that are not
+        in the snapshot. Try it with --dry-run first.
+      warning-restic-version: --dry-run, --delete and --overwrite require restic 0.17 or newer.
+      warning-mount: mount needs FUSE, exposes the snapshots read-only, and keeps
+        running until you stop it with Ctrl-C.
+      title-walkthrough: Recovery walkthrough
+      hint-walkthrough: The usual sequence when the repository is all that is left,
+        built from the settings above.
+      walkthrough-snapshots: List the snapshots of the repository
+      walkthrough-find: Find which snapshot holds the file you need
+      walkthrough-ls: List the files of the chosen snapshot
+      walkthrough-restore: Restore only the files you need
+      walkthrough-mount: Or browse the repository and copy files out by hand
+      title-backrest: Backrest cheat sheet
+      table-item: Item
+      table-value: Default path or format (Docker image between parentheses)
+      backrest-config: Config file, holding the repository URI, its password and the
+        backend environment variables
+      backrest-data: Data directory
+      backrest-binary: Restic binary downloaded by Backrest
+      backrest-plan-tag: Tag identifying the plan
+      backrest-instance-tag: Tag identifying the instance
+      hint-backrest: "A Backrest repository is a plain restic repository: if the web
+        UI is gone, read the URI and the password out of config.json and drive it
+        with the restic binary Backrest already downloaded."
   external-self-hosted-required: External Self Hosted Required
 collapsibleToolMenu:
   text:

--- a/src/tools/restic-command-generator/index.ts
+++ b/src/tools/restic-command-generator/index.ts
@@ -1,0 +1,25 @@
+import { defineTool } from '../tool';
+import { translate as t } from '@/plugins/i18n.plugin';
+
+export const tool = defineTool({
+  name: t('tools.restic-command-generator.title'),
+  path: '/restic-command-generator',
+  description: t('tools.restic-command-generator.description'),
+  keywords: [
+    'restic',
+    'backrest',
+    'restore',
+    'backup',
+    'snapshot',
+    'repository',
+    'command',
+    'generator',
+    's3',
+    'backblaze',
+    'b2',
+  ],
+  component: () => import('./restic-command-generator.vue'),
+  icon: defineAsyncComponent(() => import('@vicons/tabler/es/DatabaseImport')),
+  createdAt: new Date('2026-09-11'),
+  category: 'Network',
+});

--- a/src/tools/restic-command-generator/restic-command-generator.service.test.ts
+++ b/src/tools/restic-command-generator/restic-command-generator.service.test.ts
@@ -1,0 +1,354 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type ResticCommandConfig,
+  buildEnvironmentLines,
+  buildRepositoryUri,
+  buildResticCommand,
+  buildResticScript,
+  buildSnapshotArgument,
+  buildTagFilters,
+  defaultResticCommandConfig,
+  quoteShellArg,
+} from './restic-command-generator.service';
+
+function makeConfig(overrides: Partial<ResticCommandConfig> = {}): ResticCommandConfig {
+  return { ...defaultResticCommandConfig, ...overrides };
+}
+
+const b2Repository = 's3:s3.us-west-004.backblazeb2.com/my-backup-bucket/backrest';
+
+describe('restic-command-generator.service', () => {
+  describe('quoteShellArg', () => {
+    it('leaves shell-safe values untouched', () => {
+      expect(quoteShellArg('/mnt/restore')).toBe('/mnt/restore');
+      expect(quoteShellArg('plan:daily-docs')).toBe('plan:daily-docs');
+      expect(quoteShellArg('~/restore')).toBe('~/restore');
+      expect(quoteShellArg(b2Repository)).toBe(b2Repository);
+    });
+
+    it('quotes globs so the shell does not expand them', () => {
+      expect(quoteShellArg('/home/me/**/*.pdf')).toBe("'/home/me/**/*.pdf'");
+      expect(quoteShellArg('my documents')).toBe("'my documents'");
+    });
+
+    it('escapes single quotes', () => {
+      expect(quoteShellArg("/data/o'brien/notes")).toBe("'/data/o'\\''brien/notes'");
+    });
+
+    it('quotes empty values', () => {
+      expect(quoteShellArg('')).toBe("''");
+    });
+  });
+
+  describe('buildRepositoryUri', () => {
+    it('builds a local repository path', () => {
+      expect(buildRepositoryUri(makeConfig({ backend: 'local', localPath: '/mnt/backups/repo' }))).toBe(
+        '/mnt/backups/repo',
+      );
+    });
+
+    it('builds an S3 compatible uri and drops the scheme of the endpoint', () => {
+      expect(buildRepositoryUri(makeConfig())).toBe(b2Repository);
+      expect(
+        buildRepositoryUri(
+          makeConfig({
+            s3Endpoint: 'https://s3.eu-central-003.backblazeb2.com/',
+            s3Bucket: '/bucket/',
+            s3Prefix: '/nested/path/',
+          }),
+        ),
+      ).toBe('s3:s3.eu-central-003.backblazeb2.com/bucket/nested/path');
+    });
+
+    it('builds a Backblaze B2 native uri', () => {
+      expect(buildRepositoryUri(makeConfig({ backend: 'b2', b2Bucket: 'bucket', b2Prefix: 'backrest' }))).toBe(
+        'b2:bucket:backrest',
+      );
+      expect(buildRepositoryUri(makeConfig({ backend: 'b2', b2Bucket: 'bucket', b2Prefix: '' }))).toBe('b2:bucket:/');
+    });
+
+    it('builds sftp uris, switching to the url form when a port is given', () => {
+      expect(
+        buildRepositoryUri(
+          makeConfig({ backend: 'sftp', sftpUser: 'backup', sftpHost: 'nas.lan', sftpPath: '/srv/repo' }),
+        ),
+      ).toBe('sftp:backup@nas.lan:/srv/repo');
+      expect(
+        buildRepositoryUri(
+          makeConfig({
+            backend: 'sftp',
+            sftpUser: 'backup',
+            sftpHost: 'nas.lan',
+            sftpPort: '2222',
+            sftpPath: '/srv/repo',
+          }),
+        ),
+      ).toBe('sftp://backup@nas.lan:2222//srv/repo');
+    });
+
+    it('builds the remaining backend uris', () => {
+      expect(buildRepositoryUri(makeConfig({ backend: 'rest', restUrl: 'https://restic.lan:8000/' }))).toBe(
+        'rest:https://restic.lan:8000/',
+      );
+      expect(buildRepositoryUri(makeConfig({ backend: 'rclone', rcloneRemote: 'b2:bucket/repo' }))).toBe(
+        'rclone:b2:bucket/repo',
+      );
+      expect(
+        buildRepositoryUri(makeConfig({ backend: 'azure', azureContainer: 'container', azurePrefix: 'backrest' })),
+      ).toBe('azure:container:/backrest');
+      expect(buildRepositoryUri(makeConfig({ backend: 'gs', gsBucket: 'bucket', gsPrefix: '' }))).toBe('gs:bucket:/');
+      expect(buildRepositoryUri(makeConfig({ backend: 'raw', rawRepository: 'swift:container:/repo' }))).toBe(
+        'swift:container:/repo',
+      );
+    });
+  });
+
+  describe('buildSnapshotArgument', () => {
+    it('defaults to latest', () => {
+      expect(buildSnapshotArgument(makeConfig({ snapshotId: '' }))).toBe('latest');
+    });
+
+    it('appends the subfolder with a leading slash', () => {
+      expect(buildSnapshotArgument(makeConfig({ snapshotId: '4bba301e', snapshotSubfolder: 'home/me' }))).toBe(
+        '4bba301e:/home/me',
+      );
+      expect(buildSnapshotArgument(makeConfig({ snapshotId: 'latest', snapshotSubfolder: '/etc' }))).toBe(
+        'latest:/etc',
+      );
+    });
+  });
+
+  describe('buildTagFilters', () => {
+    it('ands the Backrest plan and instance into a single tag filter', () => {
+      expect(buildTagFilters(makeConfig({ backrestPlan: 'daily-docs', backrestInstance: 'homelab' }))).toEqual([
+        'plan:daily-docs,created-by:homelab',
+      ]);
+    });
+
+    it('keeps extra tags as separate (ORed) filters', () => {
+      expect(buildTagFilters(makeConfig({ backrestPlan: 'daily-docs', tags: ['manual', ' ', 'pre-upgrade'] }))).toEqual(
+        ['plan:daily-docs', 'manual', 'pre-upgrade'],
+      );
+    });
+  });
+
+  describe('buildResticCommand', () => {
+    it('generates a full restore of the latest snapshot', () => {
+      expect(buildResticCommand(makeConfig())).toBe(`restic -r ${b2Repository} restore --target /mnt/restore latest`);
+    });
+
+    it('generates a partial restore filtered on a Backrest plan', () => {
+      const command = buildResticCommand(
+        makeConfig({
+          backrestPlan: 'daily-docs',
+          backrestInstance: 'homelab',
+          includes: ['/home/me/documents/**/*.pdf'],
+          excludes: ['/home/me/documents/tmp'],
+          target: '/mnt/restore',
+          dryRun: true,
+          verify: true,
+        }),
+      );
+
+      expect(command).toBe(
+        `restic -r ${b2Repository} restore --target /mnt/restore ` +
+          `--include '/home/me/documents/**/*.pdf' --exclude /home/me/documents/tmp ` +
+          '--verify --dry-run --tag plan:daily-docs,created-by:homelab latest',
+      );
+    });
+
+    it('uses the case insensitive pattern flags when asked', () => {
+      const command = buildResticCommand(
+        makeConfig({ includes: ['*.PDF'], excludes: ['*.tmp'], caseInsensitivePatterns: true }),
+      );
+
+      expect(command).toContain("--iinclude '*.PDF'");
+      expect(command).toContain("--iexclude '*.tmp'");
+    });
+
+    it('restores a subfolder of a given snapshot with overwrite and delete', () => {
+      const command = buildResticCommand(
+        makeConfig({
+          snapshotId: '4bba301e',
+          snapshotSubfolder: '/var/lib/postgresql',
+          target: '/srv/restore',
+          overwrite: 'if-newer',
+          deleteExtraneous: true,
+          sparse: true,
+        }),
+      );
+
+      expect(command).toBe(
+        `restic -r ${b2Repository} restore --target /srv/restore --overwrite if-newer --delete --sparse ` +
+          '4bba301e:/var/lib/postgresql',
+      );
+    });
+
+    it('dumps a single file and redirects it to a local file', () => {
+      const command = buildResticCommand(
+        makeConfig({
+          operation: 'dump',
+          dumpPath: '/etc/nginx/nginx.conf',
+          dumpOutputFile: './nginx.conf',
+          backrestPlan: 'daily-docs',
+        }),
+      );
+
+      expect(command).toBe(
+        `restic -r ${b2Repository} dump --tag plan:daily-docs latest /etc/nginx/nginx.conf > ./nginx.conf`,
+      );
+    });
+
+    it('dumps a folder as a tar archive', () => {
+      expect(
+        buildResticCommand(makeConfig({ operation: 'dump', dumpArchive: 'tar', dumpPath: '/home/me/documents' })),
+      ).toBe(`restic -r ${b2Repository} dump --archive tar latest /home/me/documents`);
+    });
+
+    it('generates the snapshots, ls, find, diff, check, stats and unlock commands', () => {
+      expect(buildResticCommand(makeConfig({ operation: 'snapshots', backrestPlan: 'daily-docs' }))).toBe(
+        `restic -r ${b2Repository} snapshots --tag plan:daily-docs`,
+      );
+      expect(
+        buildResticCommand(makeConfig({ operation: 'ls', lsRecursive: true, lsDirectory: '/home/me/documents' })),
+      ).toBe(`restic -r ${b2Repository} ls --long --recursive latest /home/me/documents`);
+      expect(
+        buildResticCommand(
+          makeConfig({ operation: 'find', findPattern: '*.kdbx', caseInsensitivePatterns: true, findLong: true }),
+        ),
+      ).toBe(`restic -r ${b2Repository} find --long --ignore-case '*.kdbx'`);
+      expect(
+        buildResticCommand(makeConfig({ operation: 'find', findRestrictToSnapshot: true, snapshotId: '4bba301e' })),
+      ).toBe(`restic -r ${b2Repository} find --snapshot 4bba301e '*.conf'`);
+      expect(
+        buildResticCommand(makeConfig({ operation: 'diff', snapshotId: '4bba301e', diffSnapshotId: 'latest' })),
+      ).toBe(`restic -r ${b2Repository} diff 4bba301e latest`);
+      expect(buildResticCommand(makeConfig({ operation: 'check', checkReadDataSubset: '5%' }))).toBe(
+        `restic -r ${b2Repository} check --read-data-subset=5%`,
+      );
+      expect(buildResticCommand(makeConfig({ operation: 'stats', statsAllSnapshots: true }))).toBe(
+        `restic -r ${b2Repository} stats --mode restore-size`,
+      );
+      expect(buildResticCommand(makeConfig({ operation: 'unlock', unlockRemoveAll: true }))).toBe(
+        `restic -r ${b2Repository} unlock --remove-all`,
+      );
+    });
+
+    it('mounts the repository on a mount point', () => {
+      expect(buildResticCommand(makeConfig({ operation: 'mount', mountPoint: '/mnt/restic', allowOther: true }))).toBe(
+        `restic -r ${b2Repository} mount --allow-other /mnt/restic`,
+      );
+    });
+
+    it('adds global options, host and path filters', () => {
+      const command = buildResticCommand(
+        makeConfig({
+          operation: 'snapshots',
+          host: 'homelab',
+          paths: ['/home/me/documents'],
+          noLock: true,
+          noCache: true,
+          limitDownload: '2048',
+          retryLock: '5m',
+          insecureTls: true,
+          extraOptions: ['s3.connections=4'],
+          json: true,
+        }),
+      );
+
+      expect(command).toBe(
+        `restic -r ${b2Repository} --no-cache --no-lock --limit-download 2048 --retry-lock 5m --insecure-tls ` +
+          '-o s3.connections=4 --json snapshots --host homelab --path /home/me/documents',
+      );
+    });
+
+    it('only adds --no-lock on read-only commands', () => {
+      expect(buildResticCommand(makeConfig({ operation: 'ls', noLock: true }))).toContain('--no-lock');
+      expect(buildResticCommand(makeConfig({ operation: 'check', noLock: true }))).not.toContain('--no-lock');
+    });
+
+    it('uses the password flags instead of environment variables when asked', () => {
+      expect(
+        buildResticCommand(makeConfig({ passwordMode: 'file', passwordFile: '/root/.restic-password' })),
+      ).toContain('--password-file /root/.restic-password');
+      expect(
+        buildResticCommand(makeConfig({ passwordMode: 'command', passwordCommand: 'pass show restic/repo' })),
+      ).toContain("--password-command 'pass show restic/repo'");
+    });
+
+    it('omits the repository flag when the repository comes from the environment', () => {
+      expect(buildResticCommand(makeConfig({ repositoryMode: 'env', operation: 'snapshots' }))).toBe(
+        'restic snapshots',
+      );
+    });
+
+    it('appends free-form extra arguments verbatim', () => {
+      expect(buildResticCommand(makeConfig({ operation: 'snapshots', extraArguments: '--group-by host,tags' }))).toBe(
+        `restic -r ${b2Repository} snapshots --group-by host,tags`,
+      );
+    });
+
+    it('can break the command over several lines', () => {
+      expect(buildResticCommand(makeConfig({ operation: 'snapshots' }), { multiline: true })).toBe(
+        `restic \\\n  -r ${b2Repository} \\\n  snapshots`,
+      );
+    });
+  });
+
+  describe('buildEnvironmentLines', () => {
+    it('prompts for the secrets by default', () => {
+      expect(buildEnvironmentLines(makeConfig())).toEqual([
+        "read -rsp 'RESTIC_PASSWORD: ' RESTIC_PASSWORD && echo && export RESTIC_PASSWORD",
+        "export AWS_ACCESS_KEY_ID='<key ID>'",
+        "read -rsp 'AWS_SECRET_ACCESS_KEY: ' AWS_SECRET_ACCESS_KEY && echo && export AWS_SECRET_ACCESS_KEY",
+      ]);
+    });
+
+    it('exports placeholders when literal exports are chosen', () => {
+      expect(
+        buildEnvironmentLines(
+          makeConfig({
+            backend: 'b2',
+            repositoryMode: 'env',
+            passwordMode: 'placeholder',
+            credentialsMode: 'placeholder',
+            accountId: '0026b1c',
+          }),
+        ),
+      ).toEqual([
+        'export RESTIC_REPOSITORY=b2:my-backup-bucket:backrest',
+        "export RESTIC_PASSWORD='<repository password>'",
+        'export B2_ACCOUNT_ID=0026b1c',
+        "export B2_ACCOUNT_KEY='<application key>'",
+      ]);
+    });
+
+    it('exports the region when one is set', () => {
+      expect(buildEnvironmentLines(makeConfig({ s3Region: 'us-west-004', credentialsMode: 'placeholder' }))).toContain(
+        'export AWS_DEFAULT_REGION=us-west-004',
+      );
+    });
+
+    it('emits nothing when secrets are handled outside of the snippet', () => {
+      expect(buildEnvironmentLines(makeConfig({ passwordMode: 'none', credentialsMode: 'none' }))).toEqual([]);
+    });
+
+    it('emits no credentials for backends that do not need any', () => {
+      expect(buildEnvironmentLines(makeConfig({ backend: 'local', passwordMode: 'none' }))).toEqual([]);
+    });
+  });
+
+  describe('buildResticScript', () => {
+    it('puts the environment setup above the command', () => {
+      expect(
+        buildResticScript(makeConfig({ backend: 'local', operation: 'snapshots', passwordMode: 'placeholder' })),
+      ).toBe("export RESTIC_PASSWORD='<repository password>'\n\nrestic -r /mnt/backups/restic-repo snapshots");
+    });
+
+    it('returns the bare command when the environment setup is skipped', () => {
+      expect(
+        buildResticScript(makeConfig({ backend: 'local', operation: 'snapshots' }), { includeEnvironment: false }),
+      ).toBe('restic -r /mnt/backups/restic-repo snapshots');
+    });
+  });
+});

--- a/src/tools/restic-command-generator/restic-command-generator.service.ts
+++ b/src/tools/restic-command-generator/restic-command-generator.service.ts
@@ -1,0 +1,639 @@
+export type ResticBackend = 'local' | 's3' | 'b2' | 'sftp' | 'rest' | 'rclone' | 'azure' | 'gs' | 'raw';
+
+export type ResticOperation =
+  | 'restore'
+  | 'dump'
+  | 'mount'
+  | 'snapshots'
+  | 'ls'
+  | 'find'
+  | 'diff'
+  | 'check'
+  | 'stats'
+  | 'unlock';
+
+export type PasswordMode = 'prompt' | 'placeholder' | 'file' | 'command' | 'none';
+export type CredentialsMode = 'prompt' | 'placeholder' | 'none';
+export type RepositoryMode = 'flag' | 'env';
+export type OverwriteMode = 'default' | 'always' | 'if-changed' | 'if-newer' | 'never';
+export type StatsMode = 'restore-size' | 'files-by-contents' | 'raw-data' | 'blobs-per-file';
+export type DumpArchive = 'none' | 'tar' | 'zip';
+
+export interface ResticCommandConfig {
+  operation: ResticOperation;
+
+  // Repository
+  backend: ResticBackend;
+  repositoryMode: RepositoryMode;
+  localPath: string;
+  s3Endpoint: string;
+  s3Bucket: string;
+  s3Prefix: string;
+  s3Region: string;
+  b2Bucket: string;
+  b2Prefix: string;
+  sftpUser: string;
+  sftpHost: string;
+  sftpPort: string;
+  sftpPath: string;
+  restUrl: string;
+  rcloneRemote: string;
+  azureContainer: string;
+  azurePrefix: string;
+  gsBucket: string;
+  gsPrefix: string;
+  rawRepository: string;
+
+  // Secrets
+  passwordMode: PasswordMode;
+  passwordFile: string;
+  passwordCommand: string;
+  credentialsMode: CredentialsMode;
+  accountId: string;
+
+  // Snapshot selection
+  snapshotId: string;
+  snapshotSubfolder: string;
+  backrestPlan: string;
+  backrestInstance: string;
+  tags: string[];
+  host: string;
+  paths: string[];
+
+  // restore
+  target: string;
+  includes: string[];
+  excludes: string[];
+  caseInsensitivePatterns: boolean;
+  dryRun: boolean;
+  verify: boolean;
+  sparse: boolean;
+  deleteExtraneous: boolean;
+  overwrite: OverwriteMode;
+
+  // dump
+  dumpPath: string;
+  dumpArchive: DumpArchive;
+  dumpOutputFile: string;
+
+  // mount
+  mountPoint: string;
+  allowOther: boolean;
+
+  // ls
+  lsDirectory: string;
+  lsLong: boolean;
+  lsRecursive: boolean;
+
+  // find
+  findPattern: string;
+  findLong: boolean;
+  findRestrictToSnapshot: boolean;
+
+  // diff
+  diffSnapshotId: string;
+  diffMetadata: boolean;
+
+  // snapshots
+  snapshotsCompact: boolean;
+
+  // check
+  checkReadData: boolean;
+  checkReadDataSubset: string;
+  checkUnused: boolean;
+  checkWithCache: boolean;
+
+  // stats
+  statsMode: StatsMode;
+  statsAllSnapshots: boolean;
+
+  // unlock
+  unlockRemoveAll: boolean;
+
+  // Global options
+  json: boolean;
+  quiet: boolean;
+  verbose: boolean;
+  noCache: boolean;
+  noLock: boolean;
+  cacheDir: string;
+  limitDownload: string;
+  insecureTls: boolean;
+  retryLock: string;
+  extraOptions: string[];
+  extraArguments: string;
+}
+
+export const defaultResticCommandConfig: ResticCommandConfig = {
+  operation: 'restore',
+
+  backend: 's3',
+  repositoryMode: 'flag',
+  localPath: '/mnt/backups/restic-repo',
+  s3Endpoint: 's3.us-west-004.backblazeb2.com',
+  s3Bucket: 'my-backup-bucket',
+  s3Prefix: 'backrest',
+  s3Region: '',
+  b2Bucket: 'my-backup-bucket',
+  b2Prefix: 'backrest',
+  sftpUser: 'backup',
+  sftpHost: 'nas.lan',
+  sftpPort: '',
+  sftpPath: '/srv/restic-repo',
+  restUrl: 'https://restic.lan:8000/',
+  rcloneRemote: 'b2-remote:my-backup-bucket/backrest',
+  azureContainer: 'my-container',
+  azurePrefix: 'backrest',
+  gsBucket: 'my-backup-bucket',
+  gsPrefix: 'backrest',
+  rawRepository: '',
+
+  passwordMode: 'prompt',
+  passwordFile: '/root/.restic-password',
+  passwordCommand: 'pass show restic/repo',
+  credentialsMode: 'prompt',
+  accountId: '',
+
+  snapshotId: 'latest',
+  snapshotSubfolder: '',
+  backrestPlan: '',
+  backrestInstance: '',
+  tags: [],
+  host: '',
+  paths: [],
+
+  target: '/mnt/restore',
+  includes: [],
+  excludes: [],
+  caseInsensitivePatterns: false,
+  dryRun: false,
+  verify: false,
+  sparse: false,
+  deleteExtraneous: false,
+  overwrite: 'default',
+
+  dumpPath: '/etc/hosts',
+  dumpArchive: 'none',
+  dumpOutputFile: '',
+
+  mountPoint: '/mnt/restic',
+  allowOther: false,
+
+  lsDirectory: '',
+  lsLong: true,
+  lsRecursive: false,
+
+  findPattern: '*.conf',
+  findLong: false,
+  findRestrictToSnapshot: false,
+
+  diffSnapshotId: '',
+  diffMetadata: false,
+
+  snapshotsCompact: false,
+
+  checkReadData: false,
+  checkReadDataSubset: '',
+  checkUnused: false,
+  checkWithCache: false,
+
+  statsMode: 'restore-size',
+  statsAllSnapshots: false,
+
+  unlockRemoveAll: false,
+
+  json: false,
+  quiet: false,
+  verbose: false,
+  noCache: false,
+  noLock: false,
+  cacheDir: '',
+  limitDownload: '',
+  insecureTls: false,
+  retryLock: '',
+  extraOptions: [],
+  extraArguments: '',
+};
+
+// Commands that only read from the repository, and so may run with --no-lock.
+const READ_ONLY_OPERATIONS: ResticOperation[] = [
+  'restore',
+  'dump',
+  'mount',
+  'snapshots',
+  'ls',
+  'find',
+  'diff',
+  'stats',
+];
+
+// Commands that accept the --host/--tag/--path snapshot filters, mostly used to
+// pick which snapshot `latest` resolves to.
+const FILTERABLE_OPERATIONS: ResticOperation[] = ['restore', 'dump', 'mount', 'snapshots', 'ls', 'find', 'stats'];
+
+// Commands that take a snapshot ID as positional argument.
+const SNAPSHOT_OPERATIONS: ResticOperation[] = ['restore', 'dump', 'mount', 'ls', 'find', 'diff', 'stats'];
+
+// Characters a POSIX shell passes through untouched, so simple values stay readable.
+const SAFE_ARGUMENT_RE = /^[\w~@%+=:,./-]+$/;
+
+export function supportsSnapshotFilters(operation: ResticOperation): boolean {
+  return FILTERABLE_OPERATIONS.includes(operation);
+}
+
+export function supportsSnapshotSelection(operation: ResticOperation): boolean {
+  return SNAPSHOT_OPERATIONS.includes(operation);
+}
+
+export function supportsNoLock(operation: ResticOperation): boolean {
+  return READ_ONLY_OPERATIONS.includes(operation);
+}
+
+export function quoteShellArg(value: string): string {
+  if (value === '') {
+    return "''";
+  }
+
+  if (SAFE_ARGUMENT_RE.test(value)) {
+    return value;
+  }
+
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function cleanList(values: string[] | undefined): string[] {
+  return (values ?? []).map((value) => value.trim()).filter((value) => value.length > 0);
+}
+
+function trimSlashes(value: string): string {
+  return value.trim().replace(/^\/+|\/+$/g, '');
+}
+
+function joinRepositoryPath(...parts: string[]): string {
+  return parts
+    .map(trimSlashes)
+    .filter((part) => part.length > 0)
+    .join('/');
+}
+
+export function buildRepositoryUri(config: ResticCommandConfig): string {
+  switch (config.backend) {
+    case 'local':
+      return config.localPath.trim() || '/path/to/restic-repo';
+    case 's3': {
+      const endpoint =
+        config.s3Endpoint
+          .trim()
+          .replace(/^https?:\/\//, '')
+          .replace(/\/+$/, '') || 's3.amazonaws.com';
+      const path = joinRepositoryPath(config.s3Bucket, config.s3Prefix) || 'my-backup-bucket';
+      return `s3:${endpoint}/${path}`;
+    }
+    case 'b2':
+      return `b2:${trimSlashes(config.b2Bucket) || 'my-backup-bucket'}:${trimSlashes(config.b2Prefix) || '/'}`;
+    case 'sftp': {
+      const user = config.sftpUser.trim();
+      const host = config.sftpHost.trim() || 'backup-host';
+      const port = config.sftpPort.trim();
+      const path = config.sftpPath.trim() || '/srv/restic-repo';
+      const userPrefix = user ? `${user}@` : '';
+
+      if (port) {
+        // The URL form is the only one that takes a port; an absolute path needs
+        // the extra slash (sftp://host:22//srv/repo).
+        return `sftp://${userPrefix}${host}:${port}/${path.startsWith('/') ? `/${trimSlashes(path)}` : path}`;
+      }
+
+      return `sftp:${userPrefix}${host}:${path}`;
+    }
+    case 'rest':
+      return `rest:${config.restUrl.trim() || 'https://restic-server:8000/'}`;
+    case 'rclone':
+      return `rclone:${config.rcloneRemote.trim() || 'remote:path/to/repo'}`;
+    case 'azure':
+      return `azure:${trimSlashes(config.azureContainer) || 'my-container'}:/${trimSlashes(config.azurePrefix)}`;
+    case 'gs':
+      return `gs:${trimSlashes(config.gsBucket) || 'my-backup-bucket'}:/${trimSlashes(config.gsPrefix)}`;
+    case 'raw':
+    default:
+      return config.rawRepository.trim() || '<repository URI>';
+  }
+}
+
+export interface BackendCredential {
+  name: string;
+  value: string;
+  secret: boolean;
+}
+
+export function getBackendCredentials(config: ResticCommandConfig): BackendCredential[] {
+  const accountId = config.accountId.trim();
+
+  switch (config.backend) {
+    case 's3': {
+      const credentials: BackendCredential[] = [
+        { name: 'AWS_ACCESS_KEY_ID', value: accountId || '<key ID>', secret: false },
+        { name: 'AWS_SECRET_ACCESS_KEY', value: '<application key>', secret: true },
+      ];
+
+      if (config.s3Region.trim()) {
+        credentials.push({ name: 'AWS_DEFAULT_REGION', value: config.s3Region.trim(), secret: false });
+      }
+
+      return credentials;
+    }
+    case 'b2':
+      return [
+        { name: 'B2_ACCOUNT_ID', value: accountId || '<key ID>', secret: false },
+        { name: 'B2_ACCOUNT_KEY', value: '<application key>', secret: true },
+      ];
+    case 'azure':
+      return [
+        { name: 'AZURE_ACCOUNT_NAME', value: accountId || '<storage account>', secret: false },
+        { name: 'AZURE_ACCOUNT_KEY', value: '<account key>', secret: true },
+      ];
+    case 'gs':
+      return [
+        { name: 'GOOGLE_PROJECT_ID', value: accountId || '<project ID>', secret: false },
+        { name: 'GOOGLE_APPLICATION_CREDENTIALS', value: '/path/to/service-account.json', secret: false },
+      ];
+    default:
+      return [];
+  }
+}
+
+function buildReadSecretLine(name: string): string {
+  return `read -rsp '${name}: ' ${name} && echo && export ${name}`;
+}
+
+export function buildEnvironmentLines(config: ResticCommandConfig): string[] {
+  const lines: string[] = [];
+
+  if (config.repositoryMode === 'env') {
+    lines.push(`export RESTIC_REPOSITORY=${quoteShellArg(buildRepositoryUri(config))}`);
+  }
+
+  if (config.passwordMode === 'prompt') {
+    lines.push(buildReadSecretLine('RESTIC_PASSWORD'));
+  } else if (config.passwordMode === 'placeholder') {
+    lines.push(`export RESTIC_PASSWORD=${quoteShellArg('<repository password>')}`);
+  }
+
+  if (config.credentialsMode !== 'none') {
+    for (const credential of getBackendCredentials(config)) {
+      if (credential.secret && config.credentialsMode === 'prompt') {
+        lines.push(buildReadSecretLine(credential.name));
+      } else {
+        lines.push(`export ${credential.name}=${quoteShellArg(credential.value)}`);
+      }
+    }
+  }
+
+  return lines;
+}
+
+export function buildSnapshotArgument(config: ResticCommandConfig): string {
+  const snapshotId = config.snapshotId.trim() || 'latest';
+  const subfolder = config.snapshotSubfolder.trim();
+
+  if (!subfolder) {
+    return snapshotId;
+  }
+
+  return `${snapshotId}:${subfolder.startsWith('/') ? subfolder : `/${subfolder}`}`;
+}
+
+export function buildTagFilters(config: ResticCommandConfig): string[] {
+  const backrestTags: string[] = [];
+
+  if (config.backrestPlan.trim()) {
+    backrestTags.push(`plan:${config.backrestPlan.trim()}`);
+  }
+  if (config.backrestInstance.trim()) {
+    backrestTags.push(`created-by:${config.backrestInstance.trim()}`);
+  }
+
+  // Tags inside a single --tag are ANDed, repeated --tag flags are ORed, so the
+  // plan and the instance of the same snapshot must stay in one flag.
+  const tagFilters = backrestTags.length > 0 ? [backrestTags.join(',')] : [];
+
+  return [...tagFilters, ...cleanList(config.tags)];
+}
+
+export function buildResticArgumentGroups(config: ResticCommandConfig): string[] {
+  const groups: string[] = [];
+  const push = (flag: string, value?: string) => {
+    groups.push(value === undefined ? flag : `${flag} ${quoteShellArg(value)}`);
+  };
+  const pushPositional = (value: string) => {
+    groups.push(quoteShellArg(value));
+  };
+  const pushSnapshotFilters = () => {
+    if (config.host.trim()) {
+      push('--host', config.host.trim());
+    }
+    for (const tag of buildTagFilters(config)) {
+      push('--tag', tag);
+    }
+    for (const path of cleanList(config.paths)) {
+      push('--path', path);
+    }
+  };
+
+  if (config.repositoryMode === 'flag') {
+    push('-r', buildRepositoryUri(config));
+  }
+  if (config.passwordMode === 'file' && config.passwordFile.trim()) {
+    push('--password-file', config.passwordFile.trim());
+  }
+  if (config.passwordMode === 'command' && config.passwordCommand.trim()) {
+    push('--password-command', config.passwordCommand.trim());
+  }
+  if (config.cacheDir.trim()) {
+    push('--cache-dir', config.cacheDir.trim());
+  }
+  if (config.noCache) {
+    push('--no-cache');
+  }
+  if (config.noLock && supportsNoLock(config.operation)) {
+    push('--no-lock');
+  }
+  if (config.limitDownload.trim()) {
+    push('--limit-download', config.limitDownload.trim());
+  }
+  if (config.retryLock.trim()) {
+    push('--retry-lock', config.retryLock.trim());
+  }
+  if (config.insecureTls) {
+    push('--insecure-tls');
+  }
+  for (const option of cleanList(config.extraOptions)) {
+    push('-o', option);
+  }
+  if (config.json) {
+    push('--json');
+  }
+  if (config.quiet) {
+    push('--quiet');
+  }
+  if (config.verbose) {
+    push('--verbose');
+  }
+
+  groups.push(config.operation);
+
+  const snapshotArgument = buildSnapshotArgument(config);
+  const includeFlag = config.caseInsensitivePatterns ? '--iinclude' : '--include';
+  const excludeFlag = config.caseInsensitivePatterns ? '--iexclude' : '--exclude';
+
+  switch (config.operation) {
+    case 'restore': {
+      push('--target', config.target.trim() || '/mnt/restore');
+      for (const include of cleanList(config.includes)) {
+        push(includeFlag, include);
+      }
+      for (const exclude of cleanList(config.excludes)) {
+        push(excludeFlag, exclude);
+      }
+      if (config.overwrite !== 'default') {
+        push('--overwrite', config.overwrite);
+      }
+      if (config.deleteExtraneous) {
+        push('--delete');
+      }
+      if (config.sparse) {
+        push('--sparse');
+      }
+      if (config.verify) {
+        push('--verify');
+      }
+      if (config.dryRun) {
+        push('--dry-run');
+      }
+      pushSnapshotFilters();
+      pushPositional(snapshotArgument);
+      break;
+    }
+    case 'dump': {
+      if (config.dumpArchive !== 'none') {
+        push('--archive', config.dumpArchive);
+      }
+      pushSnapshotFilters();
+      pushPositional(snapshotArgument);
+      pushPositional(config.dumpPath.trim() || '/');
+      break;
+    }
+    case 'mount': {
+      if (config.allowOther) {
+        push('--allow-other');
+      }
+      pushSnapshotFilters();
+      pushPositional(config.mountPoint.trim() || '/mnt/restic');
+      break;
+    }
+    case 'snapshots': {
+      if (config.snapshotsCompact) {
+        push('--compact');
+      }
+      pushSnapshotFilters();
+      break;
+    }
+    case 'ls': {
+      if (config.lsLong) {
+        push('--long');
+      }
+      if (config.lsRecursive) {
+        push('--recursive');
+      }
+      pushSnapshotFilters();
+      pushPositional(snapshotArgument);
+      if (config.lsDirectory.trim()) {
+        pushPositional(config.lsDirectory.trim());
+      }
+      break;
+    }
+    case 'find': {
+      if (config.findLong) {
+        push('--long');
+      }
+      if (config.caseInsensitivePatterns) {
+        push('--ignore-case');
+      }
+      if (config.findRestrictToSnapshot) {
+        push('--snapshot', config.snapshotId.trim() || 'latest');
+      }
+      pushSnapshotFilters();
+      pushPositional(config.findPattern.trim() || '*');
+      break;
+    }
+    case 'diff': {
+      if (config.diffMetadata) {
+        push('--metadata');
+      }
+      pushPositional(snapshotArgument);
+      pushPositional(config.diffSnapshotId.trim() || 'latest');
+      break;
+    }
+    case 'check': {
+      if (config.checkReadDataSubset.trim()) {
+        groups.push(`--read-data-subset=${quoteShellArg(config.checkReadDataSubset.trim())}`);
+      } else if (config.checkReadData) {
+        push('--read-data');
+      }
+      if (config.checkUnused) {
+        push('--check-unused');
+      }
+      if (config.checkWithCache) {
+        push('--with-cache');
+      }
+      break;
+    }
+    case 'stats': {
+      push('--mode', config.statsMode);
+      pushSnapshotFilters();
+      if (!config.statsAllSnapshots) {
+        pushPositional(snapshotArgument);
+      }
+      break;
+    }
+    case 'unlock': {
+      if (config.unlockRemoveAll) {
+        push('--remove-all');
+      }
+      break;
+    }
+  }
+
+  return groups;
+}
+
+export function buildResticCommand(config: ResticCommandConfig, { multiline = false } = {}): string {
+  const groups = buildResticArgumentGroups(config);
+
+  if (config.extraArguments.trim()) {
+    groups.push(config.extraArguments.trim());
+  }
+
+  const separator = multiline ? ' \\\n  ' : ' ';
+  let command = `restic${separator}${groups.join(separator)}`;
+
+  if (config.operation === 'dump' && config.dumpOutputFile.trim()) {
+    command += ` > ${quoteShellArg(config.dumpOutputFile.trim())}`;
+  }
+
+  return command;
+}
+
+export function buildResticScript(
+  config: ResticCommandConfig,
+  { multiline = false, includeEnvironment = true } = {},
+): string {
+  const environmentLines = includeEnvironment ? buildEnvironmentLines(config) : [];
+  const command = buildResticCommand(config, { multiline });
+
+  if (environmentLines.length === 0) {
+    return command;
+  }
+
+  return `${environmentLines.join('\n')}\n\n${command}`;
+}

--- a/src/tools/restic-command-generator/restic-command-generator.vue
+++ b/src/tools/restic-command-generator/restic-command-generator.vue
@@ -1,0 +1,911 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import {
+  type ResticCommandConfig,
+  buildRepositoryUri,
+  buildResticCommand,
+  buildResticScript,
+  defaultResticCommandConfig,
+  getBackendCredentials,
+  supportsNoLock,
+  supportsSnapshotFilters,
+  supportsSnapshotSelection,
+} from './restic-command-generator.service';
+import { useITStorage } from '@/composable/queryParams';
+
+const { t } = useI18n();
+
+const config = useITStorage<ResticCommandConfig>(
+  'restic-command-generator:config',
+  { ...defaultResticCommandConfig },
+  undefined,
+  { mergeDefaults: true },
+);
+const multiline = useITStorage('restic-command-generator:multiline', true);
+const includeEnvironment = useITStorage('restic-command-generator:include-environment', true);
+
+const operationOptions = [
+  { label: t('tools.restic-command-generator.texts.operation-restore'), value: 'restore' },
+  { label: t('tools.restic-command-generator.texts.operation-dump'), value: 'dump' },
+  { label: t('tools.restic-command-generator.texts.operation-mount'), value: 'mount' },
+  { label: t('tools.restic-command-generator.texts.operation-snapshots'), value: 'snapshots' },
+  { label: t('tools.restic-command-generator.texts.operation-ls'), value: 'ls' },
+  { label: t('tools.restic-command-generator.texts.operation-find'), value: 'find' },
+  { label: t('tools.restic-command-generator.texts.operation-diff'), value: 'diff' },
+  { label: t('tools.restic-command-generator.texts.operation-check'), value: 'check' },
+  { label: t('tools.restic-command-generator.texts.operation-stats'), value: 'stats' },
+  { label: t('tools.restic-command-generator.texts.operation-unlock'), value: 'unlock' },
+];
+
+const backendOptions = [
+  { label: t('tools.restic-command-generator.texts.backend-s3'), value: 's3' },
+  { label: t('tools.restic-command-generator.texts.backend-b2'), value: 'b2' },
+  { label: t('tools.restic-command-generator.texts.backend-local'), value: 'local' },
+  { label: t('tools.restic-command-generator.texts.backend-sftp'), value: 'sftp' },
+  { label: t('tools.restic-command-generator.texts.backend-rest'), value: 'rest' },
+  { label: t('tools.restic-command-generator.texts.backend-rclone'), value: 'rclone' },
+  { label: t('tools.restic-command-generator.texts.backend-azure'), value: 'azure' },
+  { label: t('tools.restic-command-generator.texts.backend-gs'), value: 'gs' },
+  { label: t('tools.restic-command-generator.texts.backend-raw'), value: 'raw' },
+];
+
+const repositoryModeOptions = [
+  { label: t('tools.restic-command-generator.texts.repository-flag'), value: 'flag' },
+  { label: t('tools.restic-command-generator.texts.repository-env'), value: 'env' },
+];
+
+const passwordModeOptions = [
+  { label: t('tools.restic-command-generator.texts.password-prompt'), value: 'prompt' },
+  { label: t('tools.restic-command-generator.texts.password-file'), value: 'file' },
+  { label: t('tools.restic-command-generator.texts.password-command'), value: 'command' },
+  { label: t('tools.restic-command-generator.texts.password-placeholder'), value: 'placeholder' },
+  { label: t('tools.restic-command-generator.texts.password-none'), value: 'none' },
+];
+
+const credentialsModeOptions = [
+  { label: t('tools.restic-command-generator.texts.credentials-prompt'), value: 'prompt' },
+  { label: t('tools.restic-command-generator.texts.credentials-placeholder'), value: 'placeholder' },
+  { label: t('tools.restic-command-generator.texts.credentials-none'), value: 'none' },
+];
+
+const overwriteOptions = [
+  { label: t('tools.restic-command-generator.texts.overwrite-default'), value: 'default' },
+  { label: t('tools.restic-command-generator.texts.overwrite-always'), value: 'always' },
+  { label: t('tools.restic-command-generator.texts.overwrite-if-changed'), value: 'if-changed' },
+  { label: t('tools.restic-command-generator.texts.overwrite-if-newer'), value: 'if-newer' },
+  { label: t('tools.restic-command-generator.texts.overwrite-never'), value: 'never' },
+];
+
+const archiveOptions = [
+  { label: t('tools.restic-command-generator.texts.archive-none'), value: 'none' },
+  { label: t('tools.restic-command-generator.texts.archive-tar'), value: 'tar' },
+  { label: t('tools.restic-command-generator.texts.archive-zip'), value: 'zip' },
+];
+
+const statsModeOptions = [
+  { label: t('tools.restic-command-generator.texts.stats-restore-size'), value: 'restore-size' },
+  { label: t('tools.restic-command-generator.texts.stats-files-by-contents'), value: 'files-by-contents' },
+  { label: t('tools.restic-command-generator.texts.stats-raw-data'), value: 'raw-data' },
+  { label: t('tools.restic-command-generator.texts.stats-blobs-per-file'), value: 'blobs-per-file' },
+];
+
+const repositoryUri = computed(() => buildRepositoryUri(config.value));
+const credentials = computed(() => getBackendCredentials(config.value));
+const showSnapshotSelection = computed(() => supportsSnapshotSelection(config.value.operation));
+const showSnapshotFilters = computed(() => supportsSnapshotFilters(config.value.operation));
+const showNoLock = computed(() => supportsNoLock(config.value.operation));
+
+const script = computed(() =>
+  buildResticScript(config.value, { multiline: multiline.value, includeEnvironment: includeEnvironment.value }),
+);
+
+// The walk-through always shows the whole "I lost the web UI" sequence, whatever
+// the operation picked above, so the repository settings only have to be typed once.
+const walkthrough = computed(() => [
+  {
+    label: t('tools.restic-command-generator.texts.walkthrough-snapshots'),
+    command: buildResticCommand({ ...config.value, operation: 'snapshots', snapshotsCompact: true }),
+  },
+  {
+    label: t('tools.restic-command-generator.texts.walkthrough-find'),
+    command: buildResticCommand({ ...config.value, operation: 'find' }),
+  },
+  {
+    label: t('tools.restic-command-generator.texts.walkthrough-ls'),
+    command: buildResticCommand({ ...config.value, operation: 'ls', lsRecursive: true }),
+  },
+  {
+    label: t('tools.restic-command-generator.texts.walkthrough-restore'),
+    command: buildResticCommand({
+      ...config.value,
+      operation: 'restore',
+      includes: config.value.includes.length > 0 ? config.value.includes : ['/path/to/the/file'],
+    }),
+  },
+  {
+    label: t('tools.restic-command-generator.texts.walkthrough-mount'),
+    command: buildResticCommand({ ...config.value, operation: 'mount' }),
+  },
+]);
+
+const warnings = computed(() => {
+  const messages: string[] = [];
+
+  if (config.value.passwordMode === 'placeholder' || config.value.credentialsMode === 'placeholder') {
+    messages.push(t('tools.restic-command-generator.texts.warning-history'));
+  }
+  if (config.value.operation === 'restore') {
+    messages.push(t('tools.restic-command-generator.texts.warning-target'));
+  }
+  if (config.value.operation === 'restore' && config.value.deleteExtraneous) {
+    messages.push(t('tools.restic-command-generator.texts.warning-delete'));
+  }
+  if (
+    config.value.operation === 'restore' &&
+    (config.value.dryRun || config.value.deleteExtraneous || config.value.overwrite !== 'default')
+  ) {
+    messages.push(t('tools.restic-command-generator.texts.warning-restic-version'));
+  }
+  if (config.value.operation === 'mount') {
+    messages.push(t('tools.restic-command-generator.texts.warning-mount'));
+  }
+
+  return messages;
+});
+
+function reset() {
+  config.value = { ...defaultResticCommandConfig };
+}
+</script>
+
+<template>
+  <div>
+    <c-alert mb-3>
+      {{ t('tools.restic-command-generator.texts.intro') }}
+    </c-alert>
+
+    <c-card :title="t('tools.restic-command-generator.texts.title-repository')" mb-3>
+      <c-select
+        v-model:value="config.backend"
+        :options="backendOptions"
+        :label="t('tools.restic-command-generator.texts.label-backend')"
+        label-position="left"
+        label-width="180px"
+        mb-2
+      />
+
+      <template v-if="config.backend === 'local'">
+        <c-input-text
+          v-model:value="config.localPath"
+          :label="t('tools.restic-command-generator.texts.label-local-path')"
+          placeholder="/mnt/backups/restic-repo"
+          label-position="left"
+          label-width="180px"
+          raw-text
+          mb-2
+        />
+      </template>
+
+      <template v-else-if="config.backend === 's3'">
+        <c-input-text
+          v-model:value="config.s3Endpoint"
+          :label="t('tools.restic-command-generator.texts.label-endpoint')"
+          placeholder="s3.us-west-004.backblazeb2.com"
+          label-position="left"
+          label-width="180px"
+          raw-text
+          mb-2
+        />
+        <c-input-text
+          v-model:value="config.s3Bucket"
+          :label="t('tools.restic-command-generator.texts.label-bucket')"
+          label-position="left"
+          label-width="180px"
+          raw-text
+          mb-2
+        />
+        <c-input-text
+          v-model:value="config.s3Prefix"
+          :label="t('tools.restic-command-generator.texts.label-prefix')"
+          label-position="left"
+          label-width="180px"
+          raw-text
+          mb-2
+        />
+        <c-input-text
+          v-model:value="config.s3Region"
+          :label="t('tools.restic-command-generator.texts.label-region')"
+          placeholder="us-west-004"
+          label-position="left"
+          label-width="180px"
+          raw-text
+          mb-2
+        />
+      </template>
+
+      <template v-else-if="config.backend === 'b2'">
+        <c-input-text
+          v-model:value="config.b2Bucket"
+          :label="t('tools.restic-command-generator.texts.label-bucket')"
+          label-position="left"
+          label-width="180px"
+          raw-text
+          mb-2
+        />
+        <c-input-text
+          v-model:value="config.b2Prefix"
+          :label="t('tools.restic-command-generator.texts.label-prefix')"
+          label-position="left"
+          label-width="180px"
+          raw-text
+          mb-2
+        />
+      </template>
+
+      <template v-else-if="config.backend === 'sftp'">
+        <c-input-text
+          v-model:value="config.sftpUser"
+          :label="t('tools.restic-command-generator.texts.label-user')"
+          label-position="left"
+          label-width="180px"
+          raw-text
+          mb-2
+        />
+        <c-input-text
+          v-model:value="config.sftpHost"
+          :label="t('tools.restic-command-generator.texts.label-host')"
+          label-position="left"
+          label-width="180px"
+          raw-text
+          mb-2
+        />
+        <c-input-text
+          v-model:value="config.sftpPort"
+          :label="t('tools.restic-command-generator.texts.label-port')"
+          placeholder="22"
+          label-position="left"
+          label-width="180px"
+          raw-text
+          mb-2
+        />
+        <c-input-text
+          v-model:value="config.sftpPath"
+          :label="t('tools.restic-command-generator.texts.label-path')"
+          placeholder="/srv/restic-repo"
+          label-position="left"
+          label-width="180px"
+          raw-text
+          mb-2
+        />
+      </template>
+
+      <template v-else-if="config.backend === 'rest'">
+        <c-input-text
+          v-model:value="config.restUrl"
+          :label="t('tools.restic-command-generator.texts.label-url')"
+          placeholder="https://restic.lan:8000/"
+          label-position="left"
+          label-width="180px"
+          raw-text
+          mb-2
+        />
+      </template>
+
+      <template v-else-if="config.backend === 'rclone'">
+        <c-input-text
+          v-model:value="config.rcloneRemote"
+          :label="t('tools.restic-command-generator.texts.label-remote')"
+          placeholder="b2-remote:my-backup-bucket/backrest"
+          label-position="left"
+          label-width="180px"
+          raw-text
+          mb-2
+        />
+      </template>
+
+      <template v-else-if="config.backend === 'azure'">
+        <c-input-text
+          v-model:value="config.azureContainer"
+          :label="t('tools.restic-command-generator.texts.label-container')"
+          label-position="left"
+          label-width="180px"
+          raw-text
+          mb-2
+        />
+        <c-input-text
+          v-model:value="config.azurePrefix"
+          :label="t('tools.restic-command-generator.texts.label-prefix')"
+          label-position="left"
+          label-width="180px"
+          raw-text
+          mb-2
+        />
+      </template>
+
+      <template v-else-if="config.backend === 'gs'">
+        <c-input-text
+          v-model:value="config.gsBucket"
+          :label="t('tools.restic-command-generator.texts.label-bucket')"
+          label-position="left"
+          label-width="180px"
+          raw-text
+          mb-2
+        />
+        <c-input-text
+          v-model:value="config.gsPrefix"
+          :label="t('tools.restic-command-generator.texts.label-prefix')"
+          label-position="left"
+          label-width="180px"
+          raw-text
+          mb-2
+        />
+      </template>
+
+      <template v-else>
+        <c-input-text
+          v-model:value="config.rawRepository"
+          :label="t('tools.restic-command-generator.texts.label-raw-repository')"
+          placeholder="swift:container-name:/path"
+          label-position="left"
+          label-width="180px"
+          raw-text
+          mb-2
+        />
+      </template>
+
+      <c-select
+        v-model:value="config.repositoryMode"
+        :options="repositoryModeOptions"
+        :label="t('tools.restic-command-generator.texts.label-repository-mode')"
+        label-position="left"
+        label-width="180px"
+        mb-2
+      />
+
+      <c-input-text
+        :value="repositoryUri"
+        :label="t('tools.restic-command-generator.texts.label-repository-uri')"
+        label-position="left"
+        label-width="180px"
+        readonly
+        monospace
+        raw-text
+        mb-2
+      />
+
+      <c-select
+        v-model:value="config.passwordMode"
+        :options="passwordModeOptions"
+        :label="t('tools.restic-command-generator.texts.label-password')"
+        label-position="left"
+        label-width="180px"
+        mb-2
+      />
+
+      <c-input-text
+        v-if="config.passwordMode === 'file'"
+        v-model:value="config.passwordFile"
+        :label="t('tools.restic-command-generator.texts.label-password-file')"
+        placeholder="/root/.restic-password"
+        label-position="left"
+        label-width="180px"
+        raw-text
+        mb-2
+      />
+
+      <c-input-text
+        v-if="config.passwordMode === 'command'"
+        v-model:value="config.passwordCommand"
+        :label="t('tools.restic-command-generator.texts.label-password-command')"
+        placeholder="pass show restic/repo"
+        label-position="left"
+        label-width="180px"
+        raw-text
+        mb-2
+      />
+
+      <template v-if="credentials.length > 0">
+        <c-select
+          v-model:value="config.credentialsMode"
+          :options="credentialsModeOptions"
+          :label="t('tools.restic-command-generator.texts.label-credentials')"
+          label-position="left"
+          label-width="180px"
+          mb-2
+        />
+        <c-input-text
+          v-if="config.credentialsMode !== 'none'"
+          v-model:value="config.accountId"
+          :label="t('tools.restic-command-generator.texts.label-account-id')"
+          :placeholder="credentials[0].name"
+          label-position="left"
+          label-width="180px"
+          raw-text
+          mb-2
+        />
+      </template>
+
+      <div op-70 text-sm>
+        {{ t('tools.restic-command-generator.texts.hint-secrets') }}
+      </div>
+    </c-card>
+
+    <c-card :title="t('tools.restic-command-generator.texts.title-operation')" mb-3>
+      <c-select v-model:value="config.operation" :options="operationOptions" />
+    </c-card>
+
+    <c-card
+      v-if="showSnapshotSelection || showSnapshotFilters"
+      :title="t('tools.restic-command-generator.texts.title-snapshot')"
+      mb-3
+    >
+      <c-input-text
+        v-if="showSnapshotSelection"
+        v-model:value="config.snapshotId"
+        :label="t('tools.restic-command-generator.texts.label-snapshot-id')"
+        placeholder="latest"
+        label-position="left"
+        label-width="180px"
+        raw-text
+        mb-2
+      />
+
+      <c-input-text
+        v-if="showSnapshotSelection && config.operation !== 'find'"
+        v-model:value="config.snapshotSubfolder"
+        :label="t('tools.restic-command-generator.texts.label-subfolder')"
+        placeholder="/home/me/documents"
+        label-position="left"
+        label-width="180px"
+        raw-text
+        mb-2
+      />
+
+      <template v-if="showSnapshotFilters">
+        <c-input-text
+          v-model:value="config.backrestPlan"
+          :label="t('tools.restic-command-generator.texts.label-plan')"
+          placeholder="daily-documents"
+          label-position="left"
+          label-width="180px"
+          raw-text
+          mb-2
+        />
+        <c-input-text
+          v-model:value="config.backrestInstance"
+          :label="t('tools.restic-command-generator.texts.label-instance')"
+          placeholder="homelab"
+          label-position="left"
+          label-width="180px"
+          raw-text
+          mb-2
+        />
+        <c-input-text
+          v-model:value="config.host"
+          :label="t('tools.restic-command-generator.texts.label-filter-host')"
+          label-position="left"
+          label-width="180px"
+          raw-text
+          mb-2
+        />
+
+        <c-label :label="t('tools.restic-command-generator.texts.label-tags')" mb-2>
+          <div w-full>
+            <n-dynamic-input
+              v-model:value="config.tags"
+              :placeholder="t('tools.restic-command-generator.texts.placeholder-tag')"
+            />
+          </div>
+        </c-label>
+
+        <c-label :label="t('tools.restic-command-generator.texts.label-filter-paths')" mb-2>
+          <div w-full>
+            <n-dynamic-input
+              v-model:value="config.paths"
+              :placeholder="t('tools.restic-command-generator.texts.placeholder-path')"
+            />
+          </div>
+        </c-label>
+
+        <div op-70 text-sm>
+          {{ t('tools.restic-command-generator.texts.hint-tags') }}
+        </div>
+      </template>
+    </c-card>
+
+    <c-card
+      v-if="config.operation === 'restore'"
+      :title="t('tools.restic-command-generator.texts.title-restore-options')"
+      mb-3
+    >
+      <c-input-text
+        v-model:value="config.target"
+        :label="t('tools.restic-command-generator.texts.label-target')"
+        placeholder="/mnt/restore"
+        label-position="left"
+        label-width="180px"
+        raw-text
+        mb-2
+      />
+
+      <c-label :label="t('tools.restic-command-generator.texts.label-include')" mb-2>
+        <div w-full>
+          <n-dynamic-input
+            v-model:value="config.includes"
+            :placeholder="t('tools.restic-command-generator.texts.placeholder-include')"
+          />
+        </div>
+      </c-label>
+
+      <c-label :label="t('tools.restic-command-generator.texts.label-exclude')" mb-2>
+        <div w-full>
+          <n-dynamic-input
+            v-model:value="config.excludes"
+            :placeholder="t('tools.restic-command-generator.texts.placeholder-exclude')"
+          />
+        </div>
+      </c-label>
+
+      <c-select
+        v-model:value="config.overwrite"
+        :options="overwriteOptions"
+        :label="t('tools.restic-command-generator.texts.label-overwrite')"
+        label-position="left"
+        label-width="180px"
+        mb-2
+      />
+
+      <div flex flex-wrap gap-4>
+        <n-checkbox v-model:checked="config.caseInsensitivePatterns">
+          {{ t('tools.restic-command-generator.texts.label-case-insensitive') }}
+        </n-checkbox>
+        <n-checkbox v-model:checked="config.dryRun">
+          {{ t('tools.restic-command-generator.texts.label-dry-run') }}
+        </n-checkbox>
+        <n-checkbox v-model:checked="config.verify">
+          {{ t('tools.restic-command-generator.texts.label-verify') }}
+        </n-checkbox>
+        <n-checkbox v-model:checked="config.sparse">
+          {{ t('tools.restic-command-generator.texts.label-sparse') }}
+        </n-checkbox>
+        <n-checkbox v-model:checked="config.deleteExtraneous">
+          {{ t('tools.restic-command-generator.texts.label-delete') }}
+        </n-checkbox>
+      </div>
+    </c-card>
+
+    <c-card
+      v-if="config.operation === 'dump'"
+      :title="t('tools.restic-command-generator.texts.title-dump-options')"
+      mb-3
+    >
+      <c-input-text
+        v-model:value="config.dumpPath"
+        :label="t('tools.restic-command-generator.texts.label-dump-path')"
+        placeholder="/etc/nginx/nginx.conf"
+        label-position="left"
+        label-width="180px"
+        raw-text
+        mb-2
+      />
+      <c-select
+        v-model:value="config.dumpArchive"
+        :options="archiveOptions"
+        :label="t('tools.restic-command-generator.texts.label-archive')"
+        label-position="left"
+        label-width="180px"
+        mb-2
+      />
+      <c-input-text
+        v-model:value="config.dumpOutputFile"
+        :label="t('tools.restic-command-generator.texts.label-output-file')"
+        placeholder="./nginx.conf"
+        label-position="left"
+        label-width="180px"
+        raw-text
+        mb-2
+      />
+      <div op-70 text-sm>
+        {{ t('tools.restic-command-generator.texts.hint-dump') }}
+      </div>
+    </c-card>
+
+    <c-card
+      v-if="config.operation === 'mount'"
+      :title="t('tools.restic-command-generator.texts.title-mount-options')"
+      mb-3
+    >
+      <c-input-text
+        v-model:value="config.mountPoint"
+        :label="t('tools.restic-command-generator.texts.label-mount-point')"
+        placeholder="/mnt/restic"
+        label-position="left"
+        label-width="180px"
+        raw-text
+        mb-2
+      />
+      <n-checkbox v-model:checked="config.allowOther">
+        {{ t('tools.restic-command-generator.texts.label-allow-other') }}
+      </n-checkbox>
+    </c-card>
+
+    <c-card v-if="config.operation === 'ls'" :title="t('tools.restic-command-generator.texts.title-ls-options')" mb-3>
+      <c-input-text
+        v-model:value="config.lsDirectory"
+        :label="t('tools.restic-command-generator.texts.label-ls-directory')"
+        placeholder="/home/me/documents"
+        label-position="left"
+        label-width="180px"
+        raw-text
+        mb-2
+      />
+      <div flex flex-wrap gap-4>
+        <n-checkbox v-model:checked="config.lsLong">
+          {{ t('tools.restic-command-generator.texts.label-long') }}
+        </n-checkbox>
+        <n-checkbox v-model:checked="config.lsRecursive">
+          {{ t('tools.restic-command-generator.texts.label-recursive') }}
+        </n-checkbox>
+      </div>
+    </c-card>
+
+    <c-card
+      v-if="config.operation === 'find'"
+      :title="t('tools.restic-command-generator.texts.title-find-options')"
+      mb-3
+    >
+      <c-input-text
+        v-model:value="config.findPattern"
+        :label="t('tools.restic-command-generator.texts.label-find-pattern')"
+        placeholder="*.kdbx"
+        label-position="left"
+        label-width="180px"
+        raw-text
+        mb-2
+      />
+      <div flex flex-wrap gap-4>
+        <n-checkbox v-model:checked="config.findLong">
+          {{ t('tools.restic-command-generator.texts.label-long') }}
+        </n-checkbox>
+        <n-checkbox v-model:checked="config.caseInsensitivePatterns">
+          {{ t('tools.restic-command-generator.texts.label-case-insensitive') }}
+        </n-checkbox>
+        <n-checkbox v-model:checked="config.findRestrictToSnapshot">
+          {{ t('tools.restic-command-generator.texts.label-restrict-snapshot') }}
+        </n-checkbox>
+      </div>
+    </c-card>
+
+    <c-card
+      v-if="config.operation === 'diff'"
+      :title="t('tools.restic-command-generator.texts.title-diff-options')"
+      mb-3
+    >
+      <c-input-text
+        v-model:value="config.diffSnapshotId"
+        :label="t('tools.restic-command-generator.texts.label-diff-snapshot')"
+        placeholder="latest"
+        label-position="left"
+        label-width="180px"
+        raw-text
+        mb-2
+      />
+      <n-checkbox v-model:checked="config.diffMetadata">
+        {{ t('tools.restic-command-generator.texts.label-metadata') }}
+      </n-checkbox>
+    </c-card>
+
+    <c-card
+      v-if="config.operation === 'snapshots'"
+      :title="t('tools.restic-command-generator.texts.title-snapshots-options')"
+      mb-3
+    >
+      <n-checkbox v-model:checked="config.snapshotsCompact">
+        {{ t('tools.restic-command-generator.texts.label-compact') }}
+      </n-checkbox>
+    </c-card>
+
+    <c-card
+      v-if="config.operation === 'check'"
+      :title="t('tools.restic-command-generator.texts.title-check-options')"
+      mb-3
+    >
+      <c-input-text
+        v-model:value="config.checkReadDataSubset"
+        :label="t('tools.restic-command-generator.texts.label-read-data-subset')"
+        placeholder="5% | 1/10 | 500M"
+        label-position="left"
+        label-width="180px"
+        raw-text
+        mb-2
+      />
+      <div flex flex-wrap gap-4>
+        <n-checkbox v-model:checked="config.checkReadData" :disabled="config.checkReadDataSubset.trim().length > 0">
+          {{ t('tools.restic-command-generator.texts.label-read-data') }}
+        </n-checkbox>
+        <n-checkbox v-model:checked="config.checkUnused">
+          {{ t('tools.restic-command-generator.texts.label-check-unused') }}
+        </n-checkbox>
+        <n-checkbox v-model:checked="config.checkWithCache">
+          {{ t('tools.restic-command-generator.texts.label-with-cache') }}
+        </n-checkbox>
+      </div>
+    </c-card>
+
+    <c-card
+      v-if="config.operation === 'stats'"
+      :title="t('tools.restic-command-generator.texts.title-stats-options')"
+      mb-3
+    >
+      <c-select
+        v-model:value="config.statsMode"
+        :options="statsModeOptions"
+        :label="t('tools.restic-command-generator.texts.label-stats-mode')"
+        label-position="left"
+        label-width="180px"
+        mb-2
+      />
+      <n-checkbox v-model:checked="config.statsAllSnapshots">
+        {{ t('tools.restic-command-generator.texts.label-stats-all') }}
+      </n-checkbox>
+    </c-card>
+
+    <c-card
+      v-if="config.operation === 'unlock'"
+      :title="t('tools.restic-command-generator.texts.title-unlock-options')"
+      mb-3
+    >
+      <n-checkbox v-model:checked="config.unlockRemoveAll">
+        {{ t('tools.restic-command-generator.texts.label-remove-all') }}
+      </n-checkbox>
+    </c-card>
+
+    <c-card :title="t('tools.restic-command-generator.texts.title-global-options')" mb-3>
+      <c-input-text
+        v-model:value="config.cacheDir"
+        :label="t('tools.restic-command-generator.texts.label-cache-dir')"
+        placeholder="/var/cache/restic"
+        label-position="left"
+        label-width="180px"
+        raw-text
+        mb-2
+      />
+      <c-input-text
+        v-model:value="config.limitDownload"
+        :label="t('tools.restic-command-generator.texts.label-limit-download')"
+        placeholder="2048"
+        label-position="left"
+        label-width="180px"
+        raw-text
+        mb-2
+      />
+      <c-input-text
+        v-model:value="config.retryLock"
+        :label="t('tools.restic-command-generator.texts.label-retry-lock')"
+        placeholder="5m"
+        label-position="left"
+        label-width="180px"
+        raw-text
+        mb-2
+      />
+      <c-label :label="t('tools.restic-command-generator.texts.label-extra-options')" mb-2>
+        <div w-full>
+          <n-dynamic-input
+            v-model:value="config.extraOptions"
+            :placeholder="t('tools.restic-command-generator.texts.placeholder-extra-option')"
+          />
+        </div>
+      </c-label>
+      <c-input-text
+        v-model:value="config.extraArguments"
+        :label="t('tools.restic-command-generator.texts.label-extra-arguments')"
+        placeholder="--group-by host,tags"
+        label-position="left"
+        label-width="180px"
+        raw-text
+        mb-2
+      />
+      <div flex flex-wrap gap-4>
+        <n-checkbox v-if="showNoLock" v-model:checked="config.noLock">
+          {{ t('tools.restic-command-generator.texts.label-no-lock') }}
+        </n-checkbox>
+        <n-checkbox v-model:checked="config.noCache">
+          {{ t('tools.restic-command-generator.texts.label-no-cache') }}
+        </n-checkbox>
+        <n-checkbox v-model:checked="config.insecureTls">
+          {{ t('tools.restic-command-generator.texts.label-insecure-tls') }}
+        </n-checkbox>
+        <n-checkbox v-model:checked="config.json">
+          {{ t('tools.restic-command-generator.texts.label-json') }}
+        </n-checkbox>
+        <n-checkbox v-model:checked="config.quiet">
+          {{ t('tools.restic-command-generator.texts.label-quiet') }}
+        </n-checkbox>
+        <n-checkbox v-model:checked="config.verbose">
+          {{ t('tools.restic-command-generator.texts.label-verbose') }}
+        </n-checkbox>
+      </div>
+    </c-card>
+
+    <c-card :title="t('tools.restic-command-generator.texts.title-output')" mb-3>
+      <div flex flex-wrap gap-4 mb-3>
+        <n-checkbox v-model:checked="includeEnvironment">
+          {{ t('tools.restic-command-generator.texts.label-include-environment') }}
+        </n-checkbox>
+        <n-checkbox v-model:checked="multiline">
+          {{ t('tools.restic-command-generator.texts.label-multiline') }}
+        </n-checkbox>
+      </div>
+
+      <textarea-copyable :value="script" language="bash" word-wrap />
+
+      <c-alert v-for="warning of warnings" :key="warning" mt-3>
+        {{ warning }}
+      </c-alert>
+
+      <div mt-3 flex justify-center>
+        <c-button @click="reset()">
+          {{ t('tools.restic-command-generator.texts.button-reset') }}
+        </c-button>
+      </div>
+    </c-card>
+
+    <c-card :title="t('tools.restic-command-generator.texts.title-walkthrough')" mb-3>
+      <div op-70 text-sm mb-3>
+        {{ t('tools.restic-command-generator.texts.hint-walkthrough') }}
+      </div>
+      <div v-for="(step, index) of walkthrough" :key="step.label" mb-3>
+        <div fw-600 mb-1>{{ index + 1 }}. {{ step.label }}</div>
+        <textarea-copyable :value="step.command" language="bash" word-wrap />
+      </div>
+    </c-card>
+
+    <c-card :title="t('tools.restic-command-generator.texts.title-backrest')">
+      <table border="1" class="w-full border-collapse text-left text-sm">
+        <thead>
+          <tr>
+            <th>{{ t('tools.restic-command-generator.texts.table-item') }}</th>
+            <th>{{ t('tools.restic-command-generator.texts.table-value') }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>{{ t('tools.restic-command-generator.texts.backrest-config') }}</td>
+            <td>
+              <code>$BACKREST_CONFIG</code> —
+              <code>~/.config/backrest/config.json</code> (<code>/config/config.json</code>)
+            </td>
+          </tr>
+          <tr>
+            <td>{{ t('tools.restic-command-generator.texts.backrest-data') }}</td>
+            <td><code>$BACKREST_DATA</code> — <code>~/.local/share/backrest</code> (<code>/data</code>)</td>
+          </tr>
+          <tr>
+            <td>{{ t('tools.restic-command-generator.texts.backrest-binary') }}</td>
+            <td><code>$BACKREST_DATA/restic-&lt;version&gt;</code></td>
+          </tr>
+          <tr>
+            <td>{{ t('tools.restic-command-generator.texts.backrest-plan-tag') }}</td>
+            <td><code>plan:&lt;plan id&gt;</code></td>
+          </tr>
+          <tr>
+            <td>{{ t('tools.restic-command-generator.texts.backrest-instance-tag') }}</td>
+            <td><code>created-by:&lt;instance id&gt;</code></td>
+          </tr>
+        </tbody>
+      </table>
+      <div op-70 text-sm mt-3>
+        {{ t('tools.restic-command-generator.texts.hint-backrest') }}
+      </div>
+    </c-card>
+  </div>
+</template>
+
+<style lang="less" scoped>
+table {
+  th,
+  td {
+    padding: 4px 8px;
+  }
+}
+</style>


### PR DESCRIPTION
Generates restic CLI commands, with the focus on getting data back out of a repository when the Backrest UI is not available: a full restore, a restore limited to some files or a subfolder, a single-file dump, or a FUSE mount.

Covers the backends Backrest points at (S3 compatible such as Backblaze B2, B2 native, local, SFTP, REST, rclone, Azure, GCS, raw URI), builds the matching environment setup without ever putting a secret in the command (the default reads them with `read -rs`), and turns the Backrest plan and instance IDs into the `plan:` / `created-by:` tag filters restic expects.

Also generates the whole recovery sequence (snapshots, find, ls, restore, mount) from the same repository settings, and ships a small Backrest cheat sheet pointing at the config file, the data directory and the tag formats.

Generator only: nothing is executed and no input leaves the browser.